### PR TITLE
fix: enforce paired date and time inputs for meet creation

### DIFF
--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,77 +1,89 @@
-import React, { useEffect, useState } from "react";
-import UserManage from "@/components/UserManage";
-import { server } from "@/utils/axios";
+import React, { useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import FooterNav from "../components/FooterNav";
+import UserManage from "@/components/UserManage";
+import SearchPopup from "../components/popUp/PlaceSearch";
+import { server } from "@/utils/axios";
 
 type User = {
   id: string;
   name: string;
   email: string;
-  deposit : string;
+  deposit: string;
   previllege: string;
   uuid: string;
   isFirst: string;
 };
 
+type AdminSection = "permissions" | "createMeet";
+
 const Admin = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [hasPrivilege, setHasPrivilege] = useState<boolean | undefined>(undefined);
+  const [activeSection, setActiveSection] = useState<AdminSection>("permissions");
+
+  const [title, setTitle] = useState<string>("");
+  const [date, setDate] = useState<string>("");
+  const [time, setTime] = useState<string>("");
+  const [place, setPlace] = useState<{ name: string; xPos: string; yPos: string }>({
+    name: "",
+    xPos: "",
+    yPos: "",
+  });
+  const [content, setContent] = useState<string>("");
+  const [isPopupOpen, setIsPopupOpen] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const isLoading = useMemo(() => hasPrivilege === undefined, [hasPrivilege]);
 
   useEffect(() => {
     fetchPrevilege();
   }, []);
 
   useEffect(() => {
-    if(hasPrivilege == undefined){
+    if (hasPrivilege === undefined) {
       return;
     }
-    if(hasPrivilege){
+
+    if (!hasPrivilege) {
+      window.location.href = "/Unauthorized";
+      return;
+    }
+
+    if (activeSection === "permissions") {
       fetchUserList();
     }
-    else{
-      window.location.href = '/Unauthorized'
-    }
-  }, [hasPrivilege]);
+  }, [hasPrivilege, activeSection]);
 
   const fetchPrevilege = async () => {
-    await server.get(
-      "/member/previllege",
-    )
-    .then((response) => {
-      setHasPrivilege(response.data.previllege === "admin");
-    })
-    .catch(() => {
-      setHasPrivilege(false);
-    })
-
-    
+    await server
+      .get("/member/previllege")
+      .then((response) => {
+        setHasPrivilege(response.data.previllege === "admin");
+      })
+      .catch(() => {
+        setHasPrivilege(false);
+      });
   };
 
-  // UUID 가져오기
   const fetchUUID = async (memberId: string): Promise<string | null> => {
     try {
       const tokenResponse = await server.get("/auth/admin/accessToken");
       const adminAccessToken = tokenResponse.data.adminAccessToken;
 
-      const response = await axios.get(
-        "https://kapi.kakao.com/v1/api/talk/friends",
-        {
-          headers: {
-            Authorization: `Bearer ${adminAccessToken}`,
-          },
-        }
-      );
-
-      console.log('Kakao API 응답:', response.data);
+      const response = await axios.get("https://kapi.kakao.com/v1/api/talk/friends", {
+        headers: {
+          Authorization: `Bearer ${adminAccessToken}`,
+        },
+      });
 
       const friends = response.data.elements;
       for (let i = 0; i < friends.length; i++) {
-          if (friends[i].id.toString() == memberId) {
-              return friends[i].uuid;
-          }
+        if (friends[i].id.toString() === memberId) {
+          return friends[i].uuid;
+        }
       }
-      // 일치하는 id가 없으면 null 반환
+
       return null;
     } catch (error) {
       console.error("UUID를 가져오는 중 오류가 발생했습니다:", error);
@@ -79,7 +91,6 @@ const Admin = () => {
     }
   };
 
-  // 서버에서 유저 목록 가져오기
   const fetchUserList = async () => {
     server
       .get("/member/list")
@@ -98,23 +109,20 @@ const Admin = () => {
           console.error("예상치 못한 응답 구조:", response);
         }
       })
-      .catch ((error) => {
-      console.error("유저 목록을 불러오는 중 오류가 발생했습니다:", error);
-    });
+      .catch((error) => {
+        console.error("유저 목록을 불러오는 중 오류가 발생했습니다:", error);
+      });
   };
 
-  // 유저 권한 변경
   const handlePermissionChange = (
     memberId: string,
     currentPrivilege: string,
     uuid: string,
     isFirst: string
   ) => {
-    const newPrivilege = 
-      currentPrivilege === "accept" || currentPrivilege === "admin" 
-        ? "deny" 
-        : "accept";
-    
+    const newPrivilege =
+      currentPrivilege === "accept" || currentPrivilege === "admin" ? "deny" : "accept";
+
     const updatePrivilege = (fetchedUUID: string) => {
       const requestData = {
         memberId,
@@ -127,7 +135,7 @@ const Admin = () => {
         .then(() => {
           setUsers((prevState) =>
             prevState.map((user) =>
-              user.id === memberId ? { ...user, previllege: newPrivilege, uuid:fetchedUUID } : user
+              user.id === memberId ? { ...user, previllege: newPrivilege, uuid: fetchedUUID } : user
             )
           );
         })
@@ -138,13 +146,14 @@ const Admin = () => {
 
     if (isFirst === "true") {
       fetchUUID(memberId)
-        .then((uuid) => {
-          if (uuid) {
-            updatePrivilege(uuid);
+        .then((fetchedUUID) => {
+          if (fetchedUUID) {
+            updatePrivilege(fetchedUUID);
           } else {
             console.error("UUID를 가져오지 못했습니다. 권한 변경이 실패했습니다.");
           }
-        }).catch((error) => {
+        })
+        .catch((error) => {
           console.error("UUID를 가져오는 중 오류가 발생했습니다:", error);
         });
     } else {
@@ -152,29 +161,271 @@ const Admin = () => {
     }
   };
 
-  return (
-    <div
-      className="min-h-screen w-full flex flex-col"
-      style={{ backgroundColor: "#F2F2F7", paddingBottom: "80px" }}
-    >
-      {/* Main Content Area */}
-      <div className="flex-grow m-8">
-        <div>
-          <h1 className="text-2xl font-bold mb-4 pl-4 black text-left">
-            User List
-          </h1>
-          <ul className="max-w-full">
-            {users.map((user) => (
-              <UserManage
-                key={user.id}
-                user={user}
-                handlePermissionChange={handlePermissionChange}
-              />
-            ))}
-          </ul>
-        </div>
+  const resetMeetForm = () => {
+    setTitle("");
+    setDate("");
+    setTime("");
+    setPlace({ name: "", xPos: "", yPos: "" });
+    setContent("");
+  };
+
+  const handleMeetCreate = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!title.trim()) {
+      alert("제목을 입력해 주세요");
+      return;
+    }
+
+    const hasDate = !!date.trim();
+    const hasTime = !!time.trim();
+
+    if ((hasDate && !hasTime) || (hasTime && !hasDate)) {
+      alert("날짜와 시간은 함께 입력해 주세요");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const payload: {
+      title: string;
+      content?: string;
+      date?: string;
+      time?: string;
+      place?: { name: string; xPos: string; yPos: string };
+      type: "CUSTOM";
+    } = {
+      title,
+      type: "CUSTOM",
+    };
+
+    if (content.trim()) {
+      payload.content = content.trim();
+    }
+
+    if (hasDate) {
+      payload.date = date.trim();
+    }
+
+    if (hasTime) {
+      payload.time = time.trim();
+    }
+
+    if (place.name && place.xPos && place.yPos) {
+      payload.place = place;
+    }
+
+    server
+      .post("/meet", {
+        data: payload,
+      })
+      .then(() => {
+        alert("모임이 생성되었습니다.");
+        resetMeetForm();
+      })
+      .catch((error) => {
+        console.error("모임을 생성하는 중 오류가 발생했습니다:", error);
+        alert("모임 생성에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  };
+
+  const handlePopupSelect = (location: { x: string; y: string; address: string }) => {
+    setPlace({
+      name: location.address,
+      xPos: location.x,
+      yPos: location.y,
+    });
+    setIsPopupOpen(false);
+  };
+
+  const renderPermissionSection = () => (
+    <div className="space-y-6">
+      <div className="bg-white rounded-[24px] p-5 shadow-sm sm:p-6">
+        <h2 className="mb-3 text-left text-lg font-semibold sm:mb-4 sm:text-xl">멤버 권한 관리</h2>
+        <p className="mb-5 text-left text-xs text-[#8E8E93] sm:mb-6 sm:text-sm">
+          모임 운영진의 승인 여부를 손쉽게 관리할 수 있습니다.
+        </p>
+        <ul className="space-y-4">
+          {users.map((user) => (
+            <UserManage
+              key={user.id}
+              user={user}
+              handlePermissionChange={handlePermissionChange}
+            />
+          ))}
+          {users.length === 0 && (
+            <li className="text-center text-[#8E8E93]">표시할 멤버가 없습니다.</li>
+          )}
+        </ul>
       </div>
-      {/* 하단 네비게이션 바 */}
+    </div>
+  );
+
+  const renderMeetCreateSection = () => (
+    <div className="space-y-6">
+      <div className="bg-white rounded-[24px] p-5 shadow-sm sm:p-6">
+        <h2 className="mb-3 text-left text-lg font-semibold sm:mb-4 sm:text-xl">새 모임 생성</h2>
+        <p className="mb-5 text-left text-xs text-[#8E8E93] sm:mb-6 sm:text-sm">
+          빠르게 모임을 등록하고 구성원에게 공유할 수 있습니다.
+        </p>
+        <form className="space-y-6" onSubmit={handleMeetCreate}>
+          <div className="space-y-2 text-left">
+            <label className="text-xs text-[#8E8E93] sm:text-sm">제목</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="모임 제목을 입력하세요"
+              className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-xs text-[#8E8E93] sm:text-sm">날짜 (선택, 시간과 함께 입력)</label>
+              <input
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs text-[#8E8E93] sm:text-sm">시간 (선택, 날짜와 함께 입력)</label>
+              <input
+                type="time"
+                value={time}
+                onChange={(e) => setTime(e.target.value)}
+                className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2 text-left">
+            <label className="text-xs text-[#8E8E93] sm:text-sm">장소 (선택)</label>
+            <div className="flex items-center justify-between rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3">
+              <span className={`text-base font-semibold sm:text-lg ${place.name ? "text-black" : "text-[#8E8E93]"}`}>
+                {place.name || "장소를 선택해 주세요"}
+              </span>
+              <button
+                type="button"
+                onClick={() => setIsPopupOpen(true)}
+                className="text-xs font-semibold text-[#3A3A3C] sm:text-sm"
+              >
+                장소 검색
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-2 text-left">
+            <label className="text-xs text-[#8E8E93] sm:text-sm">내용 (선택)</label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="모임에 대한 설명을 입력하세요"
+              rows={4}
+              className="w-full resize-none rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-sm font-medium focus:border-[#FFE607] focus:outline-none sm:text-base"
+            />
+          </div>
+
+          <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={resetMeetForm}
+              className="rounded-[16px] border border-[#D1D1D6] px-5 py-3 text-xs font-semibold text-[#3A3A3C] hover:bg-[#F2F2F7] sm:px-6 sm:text-sm"
+            >
+              초기화
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-[16px] bg-[#FFE607] px-5 py-3 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-6 sm:text-sm"
+            >
+              {isSubmitting ? "생성 중..." : "모임 생성"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
+  const sections = [
+    {
+      id: "permissions" as AdminSection,
+      title: "권한 설정",
+      description: "모임 구성원의 권한을 손쉽게 관리하세요.",
+      content: renderPermissionSection(),
+    },
+    {
+      id: "createMeet" as AdminSection,
+      title: "모임 생성",
+      description: "모임 정보를 입력하고 바로 공유할 수 있습니다.",
+      content: renderMeetCreateSection(),
+    },
+  ];
+
+  const activeSectionData = sections.find((section) => section.id === activeSection);
+
+  return (
+    <div className="min-h-screen w-full" style={{ backgroundColor: "#F2F2F7" }}>
+      <div className="mx-auto flex w-full max-w-screen-sm flex-col gap-6 px-4 pb-20 pt-8 sm:max-w-screen-md sm:px-6 sm:pb-24 sm:pt-10 lg:max-w-4xl">
+        <header className="text-left space-y-2 sm:space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#8E8E93] sm:text-sm">
+            Admin Console
+          </p>
+          <h1 className="text-2xl font-bold text-[#1C1C1E] sm:text-3xl">운영 도구 허브</h1>
+          <p className="text-sm text-[#636366] sm:text-base">
+            운영자 전용 기능을 한 곳에 모았습니다. 필요한 기능을 선택하고 바로 사용해 보세요.
+          </p>
+        </header>
+
+        <nav className="flex flex-wrap gap-2 sm:gap-3">
+          {sections.map((section) => (
+            <button
+              key={section.id}
+              type="button"
+              onClick={() => setActiveSection(section.id)}
+              className={`rounded-[16px] px-4 py-2.5 text-xs font-semibold transition-colors sm:px-5 sm:py-3 sm:text-sm ${
+                activeSection === section.id
+                  ? "bg-[#FFE607] text-black shadow-sm"
+                  : "bg-white text-[#3A3A3C] hover:bg-[#F2F2F7]"
+              }`}
+            >
+              {section.title}
+            </button>
+          ))}
+        </nav>
+
+        {isLoading && (
+          <div className="rounded-[24px] bg-white p-6 text-center text-[#8E8E93]">
+            관리자 권한을 확인하는 중입니다...
+          </div>
+        )}
+
+        {!isLoading && activeSectionData && (
+          <section className="space-y-4">
+            <div className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
+              <h2 className="text-lg font-semibold text-left text-[#1C1C1E] sm:text-xl">
+                {activeSectionData.title}
+              </h2>
+              <p className="mt-2 text-xs text-left text-[#636366] sm:text-sm">
+                {activeSectionData.description}
+              </p>
+            </div>
+            {activeSectionData.content}
+          </section>
+        )}
+      </div>
+
+      <SearchPopup
+        isOpen={isPopupOpen}
+        onClose={() => setIsPopupOpen(false)}
+        onSelect={handlePopupSelect}
+      />
+
       <FooterNav />
     </div>
   );

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,36 +1,28 @@
 import React, { useEffect, useMemo, useState } from "react";
-import axios from "axios";
+import { useNavigate } from "react-router-dom";
 import FooterNav from "../components/FooterNav";
-import UserManage from "@/components/UserManage";
 import SearchPopup from "../components/popUp/PlaceSearch";
 import { server } from "@/utils/axios";
 
-type User = {
-  id: string;
-  name: string;
-  email: string;
-  deposit: string;
-  previllege: string;
-  uuid: string;
-  isFirst: string;
-};
+type VotePlace = { name: string; xPos: string; yPos: string };
 
-type AdminSection = "permissions" | "voteManagement";
+type VoteStep = "vote" | "deadline";
 
 const Admin = () => {
-  const [users, setUsers] = useState<User[]>([]);
+  const navigate = useNavigate();
   const [hasPrivilege, setHasPrivilege] = useState<boolean | undefined>(undefined);
-  const [activeSection, setActiveSection] = useState<AdminSection>("permissions");
+  const [activeStep, setActiveStep] = useState<VoteStep>("vote");
   const [isPopupOpen, setIsPopupOpen] = useState<boolean>(false);
-  const [isVoteSubmitting, setIsVoteSubmitting] = useState<boolean>(false);
-  const [isDeadlineSubmitting, setIsDeadlineSubmitting] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [voteTitle, setVoteTitle] = useState<string>("");
-  const [voteDescription, setVoteDescription] = useState<string>("");
-  const [votePlace, setVotePlace] = useState<{ name: string; xPos: string; yPos: string }>({
+  const [voteDate, setVoteDate] = useState<string>("");
+  const [voteTime, setVoteTime] = useState<string>("");
+  const [votePlace, setVotePlace] = useState<VotePlace>({
     name: "",
     xPos: "",
     yPos: "",
   });
+  const [voteContent, setVoteContent] = useState<string>("");
   const [voteDeadline, setVoteDeadline] = useState<string>("");
   const [participationDeadline, setParticipationDeadline] = useState<string>("");
 
@@ -47,13 +39,8 @@ const Admin = () => {
 
     if (!hasPrivilege) {
       window.location.href = "/Unauthorized";
-      return;
     }
-
-    if (activeSection === "permissions") {
-      fetchUserList();
-    }
-  }, [hasPrivilege, activeSection]);
+  }, [hasPrivilege]);
 
   const fetchPrevilege = async () => {
     await server
@@ -66,105 +53,16 @@ const Admin = () => {
       });
   };
 
-  const fetchUUID = async (memberId: string): Promise<string | null> => {
-    try {
-      const tokenResponse = await server.get("/auth/admin/accessToken");
-      const adminAccessToken = tokenResponse.data.adminAccessToken;
-
-      const response = await axios.get("https://kapi.kakao.com/v1/api/talk/friends", {
-        headers: {
-          Authorization: `Bearer ${adminAccessToken}`,
-        },
-      });
-
-      const friends = response.data.elements;
-      for (let i = 0; i < friends.length; i++) {
-        if (friends[i].id.toString() === memberId) {
-          return friends[i].uuid;
-        }
-      }
-
-      return null;
-    } catch (error) {
-      console.error("UUID를 가져오는 중 오류가 발생했습니다:", error);
-      return null;
-    }
-  };
-
-  const fetchUserList = async () => {
-    server
-      .get("/member/list")
-      .then((response) => {
-        if (response && response.data && Array.isArray(response.data)) {
-          const transformedUsers = response.data.map((user: any) => {
-            if (user.previllege === "accepted") {
-              user.previllege = "accept";
-            } else if (user.previllege === "denied") {
-              user.previllege = "deny";
-            }
-            return user;
-          });
-          setUsers(transformedUsers);
-        } else {
-          console.error("예상치 못한 응답 구조:", response);
-        }
-      })
-      .catch((error) => {
-        console.error("유저 목록을 불러오는 중 오류가 발생했습니다:", error);
-      });
-  };
-
-  const handlePermissionChange = (
-    memberId: string,
-    currentPrivilege: string,
-    uuid: string,
-    isFirst: string
-  ) => {
-    const newPrivilege =
-      currentPrivilege === "accept" || currentPrivilege === "admin" ? "deny" : "accept";
-
-    const updatePrivilege = (fetchedUUID: string) => {
-      const requestData = {
-        memberId,
-        option: newPrivilege,
-        uuid: fetchedUUID,
-      };
-
-      server
-        .put("/member/previllege", { data: requestData })
-        .then(() => {
-          setUsers((prevState) =>
-            prevState.map((user) =>
-              user.id === memberId ? { ...user, previllege: newPrivilege, uuid: fetchedUUID } : user
-            )
-          );
-        })
-        .catch((error) => {
-          console.error("유저 권한을 업데이트하는 중 오류가 발생했습니다:", error);
-        });
-    };
-
-    if (isFirst === "true") {
-      fetchUUID(memberId)
-        .then((fetchedUUID) => {
-          if (fetchedUUID) {
-            updatePrivilege(fetchedUUID);
-          } else {
-            console.error("UUID를 가져오지 못했습니다. 권한 변경이 실패했습니다.");
-          }
-        })
-        .catch((error) => {
-          console.error("UUID를 가져오는 중 오류가 발생했습니다:", error);
-        });
-    } else {
-      updatePrivilege(uuid);
-    }
-  };
+  const isSchedulePairIncomplete = useMemo(() => {
+    return (voteDate && !voteTime) || (!voteDate && voteTime);
+  }, [voteDate, voteTime]);
 
   const resetVoteForm = () => {
     setVoteTitle("");
-    setVoteDescription("");
+    setVoteDate("");
+    setVoteTime("");
     setVotePlace({ name: "", xPos: "", yPos: "" });
+    setVoteContent("");
   };
 
   const resetDeadlineForm = () => {
@@ -172,7 +70,7 @@ const Admin = () => {
     setParticipationDeadline("");
   };
 
-  const handleVoteCreate = (event: React.FormEvent) => {
+  const handleNextStep = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (!voteTitle.trim()) {
@@ -180,16 +78,19 @@ const Admin = () => {
       return;
     }
 
-    setIsVoteSubmitting(true);
+    if (isSchedulePairIncomplete) {
+      alert("날짜와 시간은 함께 입력하거나 비워 주세요");
+      return;
+    }
 
-    setTimeout(() => {
-      alert("투표 생성 요청이 전송되었습니다.");
-      resetVoteForm();
-      setIsVoteSubmitting(false);
-    }, 300);
+    setActiveStep("deadline");
   };
 
-  const handleDeadlineSubmit = (event: React.FormEvent) => {
+  const handlePreviousStep = () => {
+    setActiveStep("vote");
+  };
+
+  const handleVoteSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (!voteDeadline || !participationDeadline) {
@@ -197,12 +98,49 @@ const Admin = () => {
       return;
     }
 
-    setIsDeadlineSubmitting(true);
+    setIsSubmitting(true);
 
-    setTimeout(() => {
-      alert("마감일이 업데이트되었습니다.");
-      setIsDeadlineSubmitting(false);
-    }, 300);
+    const payload = {
+      title: voteTitle.trim(),
+      date: voteDate || null,
+      time: voteTime || null,
+      place: votePlace.name ? votePlace : null,
+      content: voteContent,
+      voteDeadline,
+      participationDeadline,
+    };
+
+    server
+      .post("/meet", {
+        data: payload,
+      })
+      .then((response) => {
+        const createdMeetId = response.data?.meetId ?? response.data?.id;
+
+        resetVoteForm();
+        resetDeadlineForm();
+        setActiveStep("vote");
+
+        if (createdMeetId) {
+          navigate(`/meet/${createdMeetId}`);
+          return;
+        }
+
+        alert("투표가 생성되었습니다.");
+        navigate("/");
+      })
+      .catch((error) => {
+        if (error.code === "403") {
+          navigate("/Unauthorized");
+        } else if (error.code === "404") {
+          navigate("/not-found");
+        } else {
+          alert("투표 생성에 실패했습니다.");
+        }
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
   };
 
   const handlePopupSelect = (location: { x: string; y: string; address: string }) => {
@@ -214,194 +152,159 @@ const Admin = () => {
     setIsPopupOpen(false);
   };
 
-  const renderPermissionSection = () => (
-    <div className="space-y-6">
-      <div className="bg-white rounded-[24px] p-5 shadow-sm sm:p-6">
-        <h2 className="mb-3 text-left text-lg font-semibold sm:mb-4 sm:text-xl">멤버 권한 관리</h2>
-        <p className="mb-5 text-left text-xs text-[#8E8E93] sm:mb-6 sm:text-sm">
-          모임 운영진의 승인 여부를 손쉽게 관리할 수 있습니다.
-        </p>
-        <ul className="space-y-4">
-          {users.map((user) => (
-            <UserManage
-              key={user.id}
-              user={user}
-              handlePermissionChange={handlePermissionChange}
-            />
-          ))}
-          {users.length === 0 && (
-            <li className="text-center text-[#8E8E93]">표시할 멤버가 없습니다.</li>
+  const renderVoteStep = () => (
+    <form className="space-y-6" onSubmit={handleNextStep}>
+      <div className="space-y-2 text-left">
+        <label className="text-xs text-[#8E8E93] sm:text-sm">투표 제목<span className="ml-1 text-[#FF3B30]">*</span></label>
+        <input
+          type="text"
+          value={voteTitle}
+          onChange={(e) => setVoteTitle(e.target.value)}
+          placeholder="투표 제목을 입력하세요"
+          className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-xs text-[#8E8E93] sm:text-sm">날짜</label>
+          <input
+            type="date"
+            value={voteDate}
+            onChange={(e) => setVoteDate(e.target.value)}
+            className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs text-[#8E8E93] sm:text-sm">시간</label>
+          <input
+            type="time"
+            value={voteTime}
+            onChange={(e) => setVoteTime(e.target.value)}
+            className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+          />
+        </div>
+      </div>
+      {isSchedulePairIncomplete && (
+        <p className="text-left text-xs text-[#FF3B30] sm:text-sm">날짜와 시간은 함께 입력해야 합니다.</p>
+      )}
+
+      <div className="space-y-2 text-left">
+        <label className="text-xs text-[#8E8E93] sm:text-sm">장소</label>
+        <div className="relative">
+          <input
+            type="text"
+            readOnly
+            value={votePlace.name}
+            onFocus={() => setIsPopupOpen(true)}
+            onClick={() => setIsPopupOpen(true)}
+            placeholder="장소를 선택해 주세요"
+            className="w-full cursor-pointer rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold text-left focus:border-[#FFE607] focus:outline-none sm:text-lg"
+          />
+          {votePlace.name && (
+            <button
+              type="button"
+              onClick={() => setVotePlace({ name: "", xPos: "", yPos: "" })}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold text-[#636366] hover:text-[#1C1C1E] sm:text-sm"
+            >
+              초기화
+            </button>
           )}
-        </ul>
+        </div>
+        <p className="text-left text-[11px] text-[#8E8E93] sm:text-xs">필드를 선택하면 장소 검색 팝업이 열립니다.</p>
       </div>
-    </div>
+
+      <div className="space-y-2 text-left">
+        <label className="text-xs text-[#8E8E93] sm:text-sm">내용</label>
+        <textarea
+          value={voteContent}
+          onChange={(e) => setVoteContent(e.target.value)}
+          placeholder="투표 내용을 입력하세요"
+          rows={4}
+          className="w-full resize-none rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-sm font-medium focus:border-[#FFE607] focus:outline-none sm:text-base"
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={resetVoteForm}
+          className="rounded-[16px] border border-[#D1D1D6] px-5 py-3 text-xs font-semibold text-[#3A3A3C] hover:bg-[#F2F2F7] sm:px-6 sm:text-sm"
+        >
+          초기화
+        </button>
+        <button
+          type="submit"
+          className="rounded-[16px] bg-[#FFE607] px-5 py-3 text-xs font-semibold text-black transition-opacity hover:opacity-90 sm:px-6 sm:text-sm"
+        >
+          다음
+        </button>
+      </div>
+    </form>
   );
 
-  const renderVoteManagementSection = () => (
-    <div className="space-y-6">
-      <div className="bg-white rounded-[24px] p-5 shadow-sm sm:p-6">
-        <h2 className="mb-3 text-left text-lg font-semibold sm:mb-4 sm:text-xl">투표 생성</h2>
-        <p className="mb-5 text-left text-xs text-[#8E8E93] sm:mb-6 sm:text-sm">
-          새로운 투표를 생성하고 구성원에게 공유할 기본 정보를 입력하세요.
-        </p>
-        <form className="space-y-6" onSubmit={handleVoteCreate}>
-          <div className="space-y-2 text-left">
-            <label className="text-xs text-[#8E8E93] sm:text-sm">투표 제목</label>
-            <input
-              type="text"
-              value={voteTitle}
-              onChange={(e) => setVoteTitle(e.target.value)}
-              placeholder="투표 제목을 입력하세요"
-              className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
-            />
-          </div>
-
-          <div className="space-y-2 text-left">
-            <label className="text-xs text-[#8E8E93] sm:text-sm">설명 (선택)</label>
-            <textarea
-              value={voteDescription}
-              onChange={(e) => setVoteDescription(e.target.value)}
-              placeholder="투표에 대한 설명을 입력하세요"
-              rows={4}
-              className="w-full resize-none rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-sm font-medium focus:border-[#FFE607] focus:outline-none sm:text-base"
-            />
-          </div>
-
-          <div className="space-y-2 text-left">
-            <label className="text-xs text-[#8E8E93] sm:text-sm">장소 (선택)</label>
-            <div className="relative">
-              <input
-                type="text"
-                readOnly
-                value={votePlace.name}
-                onFocus={() => setIsPopupOpen(true)}
-                onClick={() => setIsPopupOpen(true)}
-                placeholder="장소를 선택해 주세요"
-                className="w-full cursor-pointer rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold text-left focus:border-[#FFE607] focus:outline-none sm:text-lg"
-              />
-              {votePlace.name && (
-                <button
-                  type="button"
-                  onClick={() => setVotePlace({ name: "", xPos: "", yPos: "" })}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold text-[#636366] hover:text-[#1C1C1E] sm:text-sm"
-                >
-                  초기화
-                </button>
-              )}
-            </div>
-            <p className="text-left text-[11px] text-[#8E8E93] sm:text-xs">필드를 선택하면 장소 검색 팝업이 열립니다.</p>
-          </div>
-
-          <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:justify-end">
-            <button
-              type="button"
-              onClick={resetVoteForm}
-              className="rounded-[16px] border border-[#D1D1D6] px-5 py-3 text-xs font-semibold text-[#3A3A3C] hover:bg-[#F2F2F7] sm:px-6 sm:text-sm"
-            >
-              입력 초기화
-            </button>
-            <button
-              type="submit"
-              disabled={isVoteSubmitting}
-              className="rounded-[16px] bg-[#FFE607] px-5 py-3 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-6 sm:text-sm"
-            >
-              {isVoteSubmitting ? "전송 중..." : "투표 생성"}
-            </button>
-          </div>
-        </form>
+  const renderDeadlineStep = () => (
+    <form className="space-y-6" onSubmit={handleVoteSubmit}>
+      <div className="space-y-2 text-left">
+        <label className="text-xs text-[#8E8E93] sm:text-sm">투표 마감일<span className="ml-1 text-[#FF3B30]">*</span></label>
+        <input
+          type="date"
+          value={voteDeadline}
+          onChange={(e) => setVoteDeadline(e.target.value)}
+          className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+        />
+      </div>
+      <div className="space-y-2 text-left">
+        <label className="text-xs text-[#8E8E93] sm:text-sm">참여 여부 마감일<span className="ml-1 text-[#FF3B30]">*</span></label>
+        <input
+          type="date"
+          value={participationDeadline}
+          onChange={(e) => setParticipationDeadline(e.target.value)}
+          className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
+        />
       </div>
 
-      <div className="bg-white rounded-[24px] p-5 shadow-sm sm:p-6">
-        <h2 className="mb-3 text-left text-lg font-semibold sm:mb-4 sm:text-xl">투표 마감 관리</h2>
-        <p className="mb-5 text-left text-xs text-[#8E8E93] sm:mb-6 sm:text-sm">
-          투표 종료일과 참여 여부 확인 마감일을 각각 지정하세요. 시간은 서버에서 자동으로 처리됩니다.
-        </p>
-        <form className="space-y-6" onSubmit={handleDeadlineSubmit}>
-          <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-xs text-[#8E8E93] sm:text-sm">투표 마감일</label>
-              <input
-                type="date"
-                value={voteDeadline}
-                onChange={(e) => setVoteDeadline(e.target.value)}
-                className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-xs text-[#8E8E93] sm:text-sm">참여 여부 마감일</label>
-              <input
-                type="date"
-                value={participationDeadline}
-                onChange={(e) => setParticipationDeadline(e.target.value)}
-                className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
-              />
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:justify-end">
-            <button
-              type="button"
-              onClick={resetDeadlineForm}
-              className="rounded-[16px] border border-[#D1D1D6] px-5 py-3 text-xs font-semibold text-[#3A3A3C] hover:bg-[#F2F2F7] sm:px-6 sm:text-sm"
-            >
-              날짜 초기화
-            </button>
-            <button
-              type="submit"
-              disabled={isDeadlineSubmitting}
-              className="rounded-[16px] bg-[#FFE607] px-5 py-3 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-6 sm:text-sm"
-            >
-              {isDeadlineSubmitting ? "저장 중..." : "마감일 저장"}
-            </button>
-          </div>
-        </form>
+      <div className="flex flex-col gap-3 pt-4 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={handlePreviousStep}
+          className="rounded-[16px] border border-[#D1D1D6] px-5 py-3 text-xs font-semibold text-[#3A3A3C] hover:bg-[#F2F2F7] sm:px-6 sm:text-sm"
+        >
+          이전
+        </button>
+        <button
+          type="button"
+          onClick={resetDeadlineForm}
+          className="rounded-[16px] border border-[#D1D1D6] px-5 py-3 text-xs font-semibold text-[#3A3A3C] hover:bg-[#F2F2F7] sm:px-6 sm:text-sm"
+        >
+          초기화
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-[16px] bg-[#FFE607] px-5 py-3 text-xs font-semibold text-black transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 sm:px-6 sm:text-sm"
+        >
+          {isSubmitting ? "생성 중..." : "투표 생성"}
+        </button>
       </div>
-    </div>
+    </form>
   );
 
-  const sections = [
-    {
-      id: "permissions" as AdminSection,
-      title: "권한 설정",
-      description: "모임 구성원의 권한을 손쉽게 관리하세요.",
-      content: renderPermissionSection(),
-    },
-    {
-      id: "voteManagement" as AdminSection,
-      title: "투표 관리",
-      description: "투표 생성과 마감 일정을 한곳에서 설정하세요.",
-      content: renderVoteManagementSection(),
-    },
-  ];
-
-  const activeSectionData = sections.find((section) => section.id === activeSection);
+  const stepTitle = activeStep === "vote" ? "투표 생성" : "투표 마감 관리";
+  const stepDescription =
+    activeStep === "vote"
+      ? "투표 기본 정보를 입력한 후 다음 단계로 넘어가세요."
+      : "투표 종료일과 참여 여부 확인 마감일을 설정하세요. 시간은 서버에서 자동으로 처리됩니다.";
 
   return (
     <div className="min-h-screen w-full" style={{ backgroundColor: "#F2F2F7" }}>
       <div className="mx-auto flex w-full max-w-screen-sm flex-col gap-6 px-4 pb-20 pt-8 sm:max-w-screen-md sm:px-6 sm:pb-24 sm:pt-10 lg:max-w-4xl">
-        <header className="text-left space-y-2 sm:space-y-3">
+        <header className="space-y-2 text-left sm:space-y-3">
           <h1 className="text-2xl font-bold text-[#1C1C1E] sm:text-3xl">ADMIN</h1>
           <p className="text-sm text-[#636366] sm:text-base">
-            운영자 전용 기능을 한 곳에 모았습니다. 필요한 기능을 선택하고 바로 사용해 보세요.
+            운영자 전용 기능을 한 곳에 모았습니다. 필요한 정보를 입력하고 투표를 생성하세요.
           </p>
         </header>
-
-        <nav className="flex flex-wrap gap-2 sm:gap-3">
-          {sections.map((section) => (
-            <button
-              key={section.id}
-              type="button"
-              onClick={() => setActiveSection(section.id)}
-              className={`rounded-[16px] px-4 py-2.5 text-xs font-semibold transition-colors sm:px-5 sm:py-3 sm:text-sm ${
-                activeSection === section.id
-                  ? "bg-[#FFE607] text-black shadow-sm"
-                  : "bg-white text-[#3A3A3C] hover:bg-[#F2F2F7]"
-              }`}
-            >
-              {section.title}
-            </button>
-          ))}
-        </nav>
 
         {isLoading && (
           <div className="rounded-[24px] bg-white p-6 text-center text-[#8E8E93]">
@@ -409,17 +312,20 @@ const Admin = () => {
           </div>
         )}
 
-        {!isLoading && activeSectionData && (
+        {!isLoading && hasPrivilege && (
           <section className="space-y-4">
             <div className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
-              <h2 className="text-lg font-semibold text-left text-[#1C1C1E] sm:text-xl">
-                {activeSectionData.title}
-              </h2>
-              <p className="mt-2 text-xs text-left text-[#636366] sm:text-sm">
-                {activeSectionData.description}
-              </p>
+              <div className="flex items-center justify-between text-xs text-[#8E8E93] sm:text-sm">
+                <span>STEP {activeStep === "vote" ? "1" : "2"} / 2</span>
+                <span>{stepTitle}</span>
+              </div>
+              <h2 className="mt-3 text-left text-lg font-semibold text-[#1C1C1E] sm:text-xl">{stepTitle}</h2>
+              <p className="mt-2 text-left text-xs text-[#636366] sm:text-sm">{stepDescription}</p>
             </div>
-            {activeSectionData.content}
+
+            <div className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
+              {activeStep === "vote" ? renderVoteStep() : renderDeadlineStep()}
+            </div>
           </section>
         )}
       </div>

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -4,7 +4,7 @@ import FooterNav from "../components/FooterNav";
 import SearchPopup from "../components/popUp/PlaceSearch";
 import { server } from "@/utils/axios";
 
-type VotePlace = { name: string; xPos: string; yPos: string };
+// type VotePlace = { name: string; xPos: string; yPos: string };
 
 type VoteStep = "vote" | "deadline";
 
@@ -17,11 +17,7 @@ const Admin = () => {
   const [voteTitle, setVoteTitle] = useState<string>("");
   const [voteDate, setVoteDate] = useState<string>("");
   const [voteTime, setVoteTime] = useState<string>("");
-  const [votePlace, setVotePlace] = useState<VotePlace>({
-    name: "",
-    xPos: "",
-    yPos: "",
-  });
+  const [votePlace, setVotePlace] = useState<string>("");
   const [voteContent, setVoteContent] = useState<string>("");
   const [voteDeadline, setVoteDeadline] = useState<string>("");
   const [participationDeadline, setParticipationDeadline] = useState<string>("");
@@ -61,7 +57,7 @@ const Admin = () => {
     setVoteTitle("");
     setVoteDate("");
     setVoteTime("");
-    setVotePlace({ name: "", xPos: "", yPos: "" });
+    setVotePlace("");
     setVoteContent("");
   };
 
@@ -104,7 +100,7 @@ const Admin = () => {
       title: voteTitle.trim(),
       date: voteDate || null,
       time: voteTime || null,
-      place: votePlace.name ? votePlace : null,
+      place: votePlace ? votePlace : null,
       content: voteContent,
       voteDeadline,
       participationDeadline,
@@ -144,11 +140,7 @@ const Admin = () => {
   };
 
   const handlePopupSelect = (location: { x: string; y: string; address: string }) => {
-    setVotePlace({
-      name: location.address,
-      xPos: location.x,
-      yPos: location.y,
-    });
+    setVotePlace(location.address);
     setIsPopupOpen(false);
   };
 
@@ -195,16 +187,16 @@ const Admin = () => {
           <input
             type="text"
             readOnly
-            value={votePlace.name}
+            value={votePlace}
             onFocus={() => setIsPopupOpen(true)}
             onClick={() => setIsPopupOpen(true)}
             placeholder="장소를 선택해 주세요"
             className="w-full cursor-pointer rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold text-left focus:border-[#FFE607] focus:outline-none sm:text-lg"
           />
-          {votePlace.name && (
+          {votePlace && (
             <button
               type="button"
-              onClick={() => setVotePlace({ name: "", xPos: "", yPos: "" })}
+              onClick={() => setVotePlace("")}
               className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-semibold text-[#636366] hover:text-[#1C1C1E] sm:text-sm"
             >
               초기화


### PR DESCRIPTION
## Summary
- add validation so the meet creation form requires both date and time when either field is filled
- reuse the derived schedule flags when building the meet creation payload
- update the schedule field labels to clarify the paired input requirement

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4e274b5b08324a8522337f39ccd8b