### PR TITLE
Revamp post detail voting UI

### DIFF
--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -1,370 +1,376 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import FooterNav from "../components/FooterNav";
-import { server } from "@/utils/axios";
 
-type MeetInfo = {
+type PostDetail = {
   id: string;
   title: string;
   content: string;
-  type: string;
-  date: {
-    value: string;
-    time: string;
-    editable: string;
-  } | null;
-  place: {
-    value: string;
-    editable: string;
-    xpos: number;
-    ypos: number;
-  } | null;
-  isAuthor: string;
-  participantsNum: string;
-  participants: string[];
+  authorName: string;
+  createdAt: string;
+  isAuthor: boolean;
 };
 
-type DetailProps = {
-  meetInfo: MeetInfo;
-  formattedDate: string | null;
-  participants: string[];
-  onEdit: () => void;
-  onDelete: () => void;
+type VoteOption = {
+  id: string;
+  label: string;
+  count: number;
+  voted: boolean;
 };
 
-const MeetingDetailView: React.FC<DetailProps> = ({ meetInfo, formattedDate, participants, onEdit, onDelete }) => {
-  const detailSections = [
+type VoteType = "date" | "place" | "text";
+
+type Vote = {
+  id: string;
+  title: string;
+  type: VoteType;
+  activeYn: "Y" | "N";
+  hasVoted: boolean;
+  options: VoteOption[];
+};
+
+type ParticipationVote = {
+  id: string;
+  activeYn: "Y" | "N";
+  hasVoted: boolean;
+  yesCount: number;
+  noCount: number;
+  participantCount: number;
+};
+
+const fetchPostDetail = async (postId: string): Promise<PostDetail> => {
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  return {
+    id: postId,
+    title: "팀 빌딩 회의 일정 잡기",
+    content: "이번 주 금요일까지 가능한 시간과 장소를 투표해주세요.",
+    authorName: "지민",
+    createdAt: "2024-05-20 14:30",
+    isAuthor: true,
+  };
+};
+
+const fetchVoteList = async (): Promise<Vote[]> => {
+  await new Promise((resolve) => setTimeout(resolve, 350));
+  return [
     {
-      label: "날짜",
-      value: formattedDate ?? "날짜 미정",
-      icon: "fa-regular fa-calendar",
+      id: "vote-1",
+      title: "회의 날짜 투표",
+      type: "date",
+      activeYn: "Y",
+      hasVoted: false,
+      options: [
+        { id: "d1", label: "5/25(토)", count: 4, voted: false },
+        { id: "d2", label: "5/26(일)", count: 2, voted: false },
+        { id: "d3", label: "5/27(월)", count: 6, voted: false },
+      ],
     },
     {
-      label: "시간",
-      value: meetInfo.date?.time ? meetInfo.date.time : "시간 미정",
-      icon: "fa-regular fa-clock",
+      id: "vote-2",
+      title: "회의 장소 투표",
+      type: "place",
+      activeYn: "Y",
+      hasVoted: true,
+      options: [
+        { id: "p1", label: "강남역 스터디룸", count: 5, voted: false },
+        { id: "p2", label: "홍대 카페", count: 3, voted: true },
+        { id: "p3", label: "온라인", count: 4, voted: false },
+      ],
     },
     {
-      label: "장소",
-      value: meetInfo.place?.value ? meetInfo.place.value : "장소 미정",
-      icon: "fa-solid fa-location-dot",
+      id: "vote-3",
+      title: "공지용 메시지 톤 투표",
+      type: "text",
+      activeYn: "N",
+      hasVoted: true,
+      options: [
+        { id: "t1", label: "포멀", count: 8, voted: true },
+        { id: "t2", label: "캐주얼", count: 5, voted: false },
+        { id: "t3", label: "친근함", count: 2, voted: false },
+      ],
     },
   ];
+};
+
+const fetchParticipationVote = async (): Promise<ParticipationVote | null> => {
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  return {
+    id: "participation-1",
+    activeYn: "Y",
+    hasVoted: false,
+    yesCount: 4,
+    noCount: 1,
+    participantCount: 0,
+  };
+};
+
+const typeBadge = {
+  date: "bg-[#E0F2FE] text-[#0369A1]",
+  place: "bg-[#ECFDF3] text-[#047857]",
+  text: "bg-[#FEF3C7] text-[#92400E]",
+};
+
+const VoteOptionList: React.FC<{ options: VoteOption[]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
+  <div className="mt-4 flex flex-col gap-3">
+    {options.map((option) => (
+      <div
+        key={option.id}
+        className={`flex items-center justify-between rounded-2xl border px-4 py-3 text-[13px] font-medium transition ${
+          highlightVoted && option.voted
+            ? "border-[#1D4ED8] bg-[#EFF6FF] text-[#1E3A8A]"
+            : "border-[#E5E7EB] bg-white text-[#374151]"
+        }`}
+      >
+        <span>{option.label}</span>
+        <span className="text-[12px] font-semibold text-[#6B7280]">{option.count}표</span>
+      </div>
+    ))}
+  </div>
+);
+
+const ActiveVoteBefore: React.FC<{ vote: Vote }> = ({ vote }) => (
+  <div className="mt-4 rounded-2xl border border-dashed border-[#CBD5F5] bg-[#F8FAFF] p-4">
+    <p className="text-[13px] font-medium text-[#1E3A8A]">투표를 진행해주세요.</p>
+    <div className="mt-3 flex flex-col gap-3">
+      {vote.options.map((option) => (
+        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-[13px] text-[#374151]">
+          <input type="radio" name={`vote-${vote.id}`} className="h-4 w-4 text-[#2563EB]" />
+          {option.label}
+        </label>
+      ))}
+    </div>
+    <button className="mt-4 w-full rounded-2xl bg-[#2563EB] py-2 text-[13px] font-semibold text-white">투표하기</button>
+  </div>
+);
+
+const ActiveVoteAfter: React.FC<{ vote: Vote }> = ({ vote }) => (
+  <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F9FAFB] p-4">
+    <p className="text-[13px] font-medium text-[#111827]">내가 선택한 항목과 전체 결과</p>
+    <VoteOptionList options={vote.options} highlightVoted />
+  </div>
+);
+
+const ClosedVote: React.FC<{ vote: Vote }> = ({ vote }) => (
+  <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F3F4F6] p-4">
+    <p className="text-[13px] font-medium text-[#6B7280]">투표가 종료되었습니다.</p>
+    <VoteOptionList options={vote.options} />
+  </div>
+);
+
+const VoteCard: React.FC<{ vote: Vote; onEnd: (id: string) => void }> = ({ vote, onEnd }) => {
+  const typeLabel = vote.type === "date" ? "날짜" : vote.type === "place" ? "장소" : "텍스트";
 
   return (
-    <div className="min-h-screen w-full flex flex-col bg-[#F2F2F7]" style={{ paddingBottom: "80px" }}>
-      <header className="bg-white px-6 pt-6 pb-5 shadow-[0_6px_20px_rgba(0,0,0,0.05)]">
-        <span className="rounded-full bg-[#E1F0FF] px-3 py-1 text-[11px] font-semibold tracking-wide text-[#1E3A8A]">모임 정보</span>
-        <h1 className="mt-3 text-[23px] font-bold leading-tight text-[#111827]">{meetInfo.title}</h1>
-        <p className="mt-2 text-[13px] text-[#4B5563]">
-          {participants.length > 0 ? `${participants.length}명이 참여 중` : "아직 참여자가 없습니다."}
-        </p>
-      </header>
+    <div className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold ${typeBadge[vote.type]}`}>
+            {typeLabel} 투표
+          </span>
+          <h3 className="mt-2 text-[16px] font-semibold text-[#111827]">{vote.title}</h3>
+        </div>
+        <button
+          onClick={() => onEnd(vote.id)}
+          className="rounded-full border border-[#E5E7EB] px-3 py-1 text-[11px] font-semibold text-[#6B7280]"
+        >
+          투표 종료
+        </button>
+      </div>
 
-      <main className="flex-1 px-6 pb-10 pt-8">
-        <section className="rounded-[24px] bg-white p-6 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
-          <div className="flex items-center justify-between border-b border-[#E5E7EB] pb-4">
-            <h2 className="text-[15px] font-semibold text-[#111827]">기본 정보</h2>
-            <span className="text-[12px] font-medium text-[#6B7280]">모임 세부사항</span>
-          </div>
-          <div className="mt-5 flex flex-col gap-4">
-            {detailSections.map((section) => (
-              <div key={section.label} className="flex items-center gap-4">
-                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#E8F1FF] text-[#1E3A8A]">
-                  <i className={`${section.icon} text-[18px]`}></i>
-                </span>
-                <div className="flex flex-col">
-                  <span className="text-[12px] font-medium text-[#6B7280]">{section.label}</span>
-                  <span className="text-[15px] font-semibold text-[#111827]">{section.value}</span>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          <div className="mt-6 rounded-2xl bg-[#F8FAFF] p-4">
-            <span className="text-[12px] font-medium text-[#6B7280]">소개</span>
-            <p className="mt-2 text-[14px] leading-relaxed text-[#1F2937]">
-              {meetInfo.content ? meetInfo.content : "등록된 소개가 없습니다."}
-            </p>
-          </div>
-        </section>
-
-        <section className="mt-6 rounded-[24px] bg-white p-6 shadow-[0_12px_32px_rgba(26,26,26,0.06)]">
-          <div className="flex items-center justify-between border-b border-[#E5E7EB] pb-4">
-            <h2 className="text-[15px] font-semibold text-[#111827]">참여자</h2>
-            <span className="text-[12px] font-medium text-[#6B7280]">{participants.length}명</span>
-          </div>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {participants.length > 0 ? (
-              participants.map((participant) => (
-                <span key={participant} className="rounded-full bg-[#E1F0FF] px-3 py-1 text-[12px] font-medium text-[#1E3A8A]">
-                  {participant}
-                </span>
-              ))
-            ) : (
-              <p className="text-[13px] text-[#6B7280]">참여자가 아직 없습니다.</p>
-            )}
-          </div>
-        </section>
-
-        {meetInfo.isAuthor === "true" && (
-          <div className="mt-8 flex gap-3">
-            <button
-              onClick={onEdit}
-              className="flex-1 rounded-[24px] bg-[#2563EB] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:bg-[#1D4ED8]"
-            >
-              수정하기
-            </button>
-            <button
-              onClick={onDelete}
-              className="flex-1 rounded-[24px] bg-[#FF3B30] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:shadow-lg"
-            >
-              삭제하기
-            </button>
-          </div>
-        )}
-      </main>
-
-      <FooterNav />
+      {vote.activeYn === "Y" ? (vote.hasVoted ? <ActiveVoteAfter vote={vote} /> : <ActiveVoteBefore vote={vote} />) : <ClosedVote vote={vote} />}
     </div>
   );
 };
 
-const TravelDetailView: React.FC<DetailProps> = ({ meetInfo, formattedDate, participants, onEdit, onDelete }) => {
-  const detailSections = [
-    {
-      label: "확정일",
-      value: formattedDate ?? "날짜 미정",
-      icon: "fa-regular fa-calendar-check",
-    },
-    {
-      label: "예산",
-      value: meetInfo.content || "예산 정보가 없습니다.",
-      icon: "fa-solid fa-wallet",
-    },
-    {
-      label: "장소",
-      value: meetInfo.place?.value ? meetInfo.place.value : "장소 미정",
-      icon: "fa-solid fa-location-dot",
-    },
-  ];
+const ParticipationVoteCard: React.FC<{
+  vote: ParticipationVote;
+  onEnd: () => void;
+}> = ({ vote, onEnd }) => {
+  if (vote.activeYn === "N") {
+    return (
+      <div className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
+        <div className="flex items-start justify-between">
+          <div>
+            <span className="inline-flex rounded-full bg-[#FEE2E2] px-3 py-1 text-[11px] font-semibold text-[#991B1B]">참여여부 투표 종료</span>
+            <h3 className="mt-2 text-[16px] font-semibold text-[#111827]">참여여부 결과</h3>
+          </div>
+          <button
+            onClick={onEnd}
+            className="rounded-full border border-[#E5E7EB] px-3 py-1 text-[11px] font-semibold text-[#6B7280]"
+          >
+            종료됨
+          </button>
+        </div>
+        <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F3F4F6] p-4">
+          <div className="flex justify-between text-[13px] text-[#374151]">
+            <span>참여</span>
+            <span className="font-semibold">{vote.yesCount}명</span>
+          </div>
+          <div className="mt-2 flex justify-between text-[13px] text-[#374151]">
+            <span>불참</span>
+            <span className="font-semibold">{vote.noCount}명</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen w-full flex flex-col bg-[#F2F2F7]" style={{ paddingBottom: "80px" }}>
-      <header className="bg-white px-6 pt-6 pb-5 shadow-[0_6px_20px_rgba(0,0,0,0.05)]">
-        <span className="rounded-full bg-[#FEF3C7] px-3 py-1 text-[11px] font-semibold tracking-wide text-[#92400E]">여행 투표</span>
-        <h1 className="mt-3 text-[23px] font-bold leading-tight text-[#111827]">{meetInfo.title}</h1>
-        <p className="mt-2 text-[13px] text-[#4B5563]">
-          {participants.length > 0 ? `${participants.length}명이 의견을 남겼습니다.` : "아직 참여자가 없습니다."}
-        </p>
-      </header>
+    <div className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
+      <div className="flex items-start justify-between">
+        <div>
+          <span className="inline-flex rounded-full bg-[#DBEAFE] px-3 py-1 text-[11px] font-semibold text-[#1D4ED8]">참여여부 투표</span>
+          <h3 className="mt-2 text-[16px] font-semibold text-[#111827]">참여 가능 여부</h3>
+        </div>
+        <button
+          onClick={onEnd}
+          className="rounded-full border border-[#E5E7EB] px-3 py-1 text-[11px] font-semibold text-[#6B7280]"
+        >
+          투표 종료
+        </button>
+      </div>
 
-      <main className="flex-1 px-6 pb-10 pt-8">
-        <section className="rounded-[24px] bg-white p-6 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
-          <div className="flex items-center justify-between border-b border-[#E5E7EB] pb-4">
-            <h2 className="text-[15px] font-semibold text-[#111827]">여행 정보</h2>
-            <span className="text-[12px] font-medium text-[#6B7280]">투표 결과</span>
+      {vote.hasVoted ? (
+        <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F9FAFB] p-4">
+          <p className="text-[13px] font-medium text-[#111827]">내가 선택한 항목과 전체 결과</p>
+          <div className="mt-3 flex flex-col gap-2 text-[13px] text-[#374151]">
+            <div className="flex justify-between">
+              <span>참여</span>
+              <span className="font-semibold">{vote.yesCount}명</span>
+            </div>
+            <div className="flex justify-between">
+              <span>불참</span>
+              <span className="font-semibold">{vote.noCount}명</span>
+            </div>
           </div>
-          <div className="mt-5 flex flex-col gap-4">
-            {detailSections.map((section) => (
-              <div key={section.label} className="flex items-center gap-4">
-                <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[#FFF7ED] text-[#EA580C]">
-                  <i className={`${section.icon} text-[18px]`}></i>
-                </span>
-                <div className="flex flex-col">
-                  <span className="text-[12px] font-medium text-[#6B7280]">{section.label}</span>
-                  <span className="text-[15px] font-semibold text-[#111827]">{section.value}</span>
-                </div>
-              </div>
-            ))}
+        </div>
+      ) : (
+        <div className="mt-4 rounded-2xl border border-dashed border-[#CBD5F5] bg-[#F8FAFF] p-4">
+          <p className="text-[13px] font-medium text-[#1E3A8A]">참여 여부를 선택해주세요.</p>
+          <div className="mt-3 flex flex-col gap-3">
+            <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-[13px] text-[#374151]">
+              <input type="radio" name="participation" className="h-4 w-4 text-[#2563EB]" />
+              참여
+            </label>
+            <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-[13px] text-[#374151]">
+              <input type="radio" name="participation" className="h-4 w-4 text-[#2563EB]" />
+              불참
+            </label>
           </div>
-        </section>
-
-        <section className="mt-6 rounded-[24px] bg-white p-6 shadow-[0_12px_32px_rgba(26,26,26,0.06)]">
-          <div className="flex items-center justify-between border-b border-[#E5E7EB] pb-4">
-            <h2 className="text-[15px] font-semibold text-[#111827]">참여자</h2>
-            <span className="text-[12px] font-medium text-[#6B7280]">{participants.length}명</span>
-          </div>
-          <div className="mt-4 flex flex-wrap gap-2">
-            {participants.length > 0 ? (
-              participants.map((participant) => (
-                <span key={participant} className="rounded-full bg-[#FEF3C7] px-3 py-1 text-[12px] font-medium text-[#92400E]">
-                  {participant}
-                </span>
-              ))
-            ) : (
-              <p className="text-[13px] text-[#6B7280]">참여자가 아직 없습니다.</p>
-            )}
-          </div>
-        </section>
-
-        {meetInfo.isAuthor === "true" && (
-          <div className="mt-8 flex gap-3">
-            <button
-              onClick={onEdit}
-              className="flex-1 rounded-[24px] bg-[#2563EB] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:bg-[#1D4ED8]"
-            >
-              수정하기
-            </button>
-            <button
-              onClick={onDelete}
-              className="flex-1 rounded-[24px] bg-[#FF3B30] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:shadow-lg"
-            >
-              삭제하기
-            </button>
-          </div>
-        )}
-      </main>
-
-      <FooterNav />
+          <button className="mt-4 w-full rounded-2xl bg-[#2563EB] py-2 text-[13px] font-semibold text-white">투표하기</button>
+        </div>
+      )}
     </div>
   );
 };
 
-const MeetDetail: React.FC = () => {
+const PostDetailPage: React.FC = () => {
   const { meetId } = useParams();
   const navigate = useNavigate();
 
-  const [meetInfo, setMeetInfo] = useState<MeetInfo | null>(null);
-  const [formattedDate, setFormattedDate] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [postDetail, setPostDetail] = useState<PostDetail | null>(null);
+  const [votes, setVotes] = useState<Vote[]>([]);
+  const [participationVote, setParticipationVote] = useState<ParticipationVote | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!meetId) {
-      return;
-    }
-
-    let redirected = false;
-
-    const normalizeDate = (value?: string | null) => {
-      if (!value) return null;
-      const date = new Date(value);
-      if (Number.isNaN(date.getTime())) {
-        return null;
-      }
-      date.setHours(0, 0, 0, 0);
-      return date;
-    };
+    let isMounted = true;
 
     const loadDetail = async () => {
-      setIsLoading(true);
-      try {
-        const [placeResponse, scheduleResponse, participationResponse] = await Promise.all([
-          server.get(`/meet/place?meetId=${meetId}`),
-          server.get(`/meet/schedule?meetId=${meetId}`),
-          server.get(`/meet/participate?meetId=${meetId}`),
-        ]);
+      if (!meetId) return;
+      setLoading(true);
 
-        const now = new Date();
-        const placeVoteEnd = normalizeDate(placeResponse.data?.endDate ?? null);
-        const scheduleVoteEnd = normalizeDate(scheduleResponse.data?.endDate ?? null);
-        const participationEnd = normalizeDate(participationResponse.data?.endDate ?? null);
+      const [postResponse, voteResponse, participationResponse] = await Promise.all([
+        fetchPostDetail(meetId),
+        fetchVoteList(),
+        fetchParticipationVote(),
+      ]);
 
-        if ((placeVoteEnd && now < placeVoteEnd) || (scheduleVoteEnd && now < scheduleVoteEnd)) {
-          redirected = true;
-          navigate(`/meet/vote/${meetId}`, { replace: true });
-          return;
-        }
-
-        if (participationEnd && now < participationEnd) {
-          redirected = true;
-          navigate(`/meet/join/${meetId}`, { replace: true });
-          return;
-        }
-
-        const detailResponse = await server.get(`/meet?meetId=${meetId}`);
-        const data = detailResponse.data;
-
-        if (typeof data.participants === "string") {
-          try {
-            data.participants = JSON.parse(data.participants.replace(/'/g, '"'));
-          } catch (parseError) {
-            console.error("참여자 데이터 파싱 오류:", parseError);
-            data.participants = [];
-          }
-        }
-
-        setMeetInfo(data);
-        const meetingDate = data.date?.value ? new Date(data.date.value) : null;
-        const normalizedDate =
-          meetingDate && !Number.isNaN(meetingDate.getTime())
-            ? new Intl.DateTimeFormat("ko-KR", {
-                year: "numeric",
-                month: "2-digit",
-                day: "2-digit",
-              }).format(meetingDate)
-            : "날짜 미정";
-        setFormattedDate(normalizedDate);
-      } catch (error: any) {
-        if (error?.code === "403") {
-          redirected = true;
-          navigate("/Unauthorized");
-        } else if (error?.code === "404") {
-          redirected = true;
-          navigate("/not-found");
-        } else {
-          console.error("모임 정보를 불러오는 중 오류가 발생했습니다:", error);
-        }
-      } finally {
-        if (!redirected) {
-          setIsLoading(false);
-        }
-      }
+      if (!isMounted) return;
+      setPostDetail(postResponse);
+      setVotes(voteResponse);
+      setParticipationVote(participationResponse);
+      setLoading(false);
     };
 
     void loadDetail();
 
     return () => {
-      redirected = true;
+      isMounted = false;
     };
-  }, [meetId, navigate]);
+  }, [meetId]);
 
-  const handleEdit = () => {
-    if (meetInfo) {
-      navigate(`/meet/edit/${meetInfo.id}`);
-    }
+  const handleEndVote = (voteId: string) => {
+    setVotes((prev) =>
+      prev.map((vote) =>
+        vote.id === voteId
+          ? {
+              ...vote,
+              activeYn: "N",
+            }
+          : vote,
+      ),
+    );
   };
 
-  const handleDelete = () => {
-    if (!meetId) {
-      return;
-    }
-
-    server
-      .delete(`/meet?meetId=${meetId}`)
-      .then(() => {
-        navigate("/");
-      })
-      .catch((error) => {
-        if (error.code === "403") {
-          navigate("/Unauthorized");
-        } else if (error.code === "404") {
-          navigate("/not-found");
-        }
-      });
+  const handleAddVote = () => {
+    setVotes((prev) => [
+      {
+        id: `vote-${prev.length + 1}`,
+        title: "새로운 투표",
+        type: "text",
+        activeYn: "Y",
+        hasVoted: false,
+        options: [
+          { id: "new-1", label: "옵션 1", count: 0, voted: false },
+          { id: "new-2", label: "옵션 2", count: 0, voted: false },
+        ],
+      },
+      ...prev,
+    ]);
   };
 
-  const participants = useMemo(() => {
-    if (!meetInfo) {
-      return [] as string[];
-    }
+  const handleCreateParticipationVote = () => {
+    setParticipationVote({
+      id: "participation-2",
+      activeYn: "Y",
+      hasVoted: false,
+      yesCount: 0,
+      noCount: 0,
+      participantCount: 0,
+    });
+  };
 
-    return Array.isArray(meetInfo.participants) ? meetInfo.participants : [];
-  }, [meetInfo]);
+  const handleEndParticipationVote = () => {
+    setParticipationVote((prev) =>
+      prev
+        ? {
+            ...prev,
+            activeYn: "N",
+            participantCount: prev.yesCount,
+          }
+        : prev,
+    );
+  };
 
-  if (isLoading) {
+  const participantCountText = useMemo(() => {
+    if (!participationVote || participationVote.activeYn !== "N") return null;
+    return `참여 인원: ${participationVote.participantCount}명`;
+  }, [participationVote]);
+
+  if (loading) {
     return (
       <div className="min-h-screen w-full flex flex-col items-center justify-center bg-[#F2F2F7]">
         <div className="h-14 w-14 animate-spin rounded-full border-4 border-[#E5E5EA] border-t-[#1E3A8A]" />
-        <p className="mt-4 text-[13px] text-[#8E8E93]">모임 정보를 불러오는 중입니다...</p>
+        <p className="mt-4 text-[13px] text-[#8E8E93]">게시글 정보를 불러오는 중입니다...</p>
       </div>
     );
   }
 
-  if (!meetInfo) {
+  if (!postDetail) {
     return (
       <div className="min-h-screen w-full flex flex-col items-center justify-center bg-[#F2F2F7] text-center">
-        <p className="text-[14px] font-medium text-[#1C1C1E]">모임 정보를 불러오지 못했습니다.</p>
+        <p className="text-[14px] font-medium text-[#1C1C1E]">게시글 정보를 불러오지 못했습니다.</p>
         <button
           onClick={() => navigate(-1)}
           className="mt-4 rounded-full bg-[#1E3A8A] px-5 py-2 text-[12px] font-semibold text-white shadow-md"
@@ -375,27 +381,86 @@ const MeetDetail: React.FC = () => {
     );
   }
 
-  if (meetInfo.type === "travel") {
-    return (
-      <TravelDetailView
-        meetInfo={meetInfo}
-        formattedDate={formattedDate}
-        participants={participants}
-        onEdit={handleEdit}
-        onDelete={handleDelete}
-      />
-    );
-  }
-
   return (
-    <MeetingDetailView
-      meetInfo={meetInfo}
-      formattedDate={formattedDate}
-      participants={participants}
-      onEdit={handleEdit}
-      onDelete={handleDelete}
-    />
+    <div className="min-h-screen w-full bg-[#F2F2F7] pb-[90px]">
+      <header className="bg-white px-6 pt-6 pb-5 shadow-[0_6px_20px_rgba(0,0,0,0.05)]">
+        <span className="rounded-full bg-[#E1F0FF] px-3 py-1 text-[11px] font-semibold tracking-wide text-[#1E3A8A]">게시글 상세</span>
+        <h1 className="mt-3 text-[23px] font-bold leading-tight text-[#111827]">{postDetail.title}</h1>
+        <div className="mt-2 flex items-center gap-2 text-[12px] text-[#6B7280]">
+          <span>{postDetail.authorName}</span>
+          <span>•</span>
+          <span>{postDetail.createdAt}</span>
+        </div>
+        <p className="mt-3 text-[14px] text-[#374151]">{postDetail.content}</p>
+      </header>
+
+      <main className="px-6 pt-6">
+        <section className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
+          <div className="flex items-center justify-between">
+            <h2 className="text-[16px] font-semibold text-[#111827]">투표 리스트</h2>
+            <button
+              onClick={handleAddVote}
+              className="rounded-full bg-[#2563EB] px-4 py-2 text-[12px] font-semibold text-white"
+            >
+              투표 추가
+            </button>
+          </div>
+          <p className="mt-2 text-[12px] text-[#6B7280]">투표는 진행중 여부에 따라 다른 컴포넌트로 표시됩니다.</p>
+        </section>
+
+        <div className="mt-5 flex flex-col gap-5">
+          {votes.map((vote) => (
+            <VoteCard key={vote.id} vote={vote} onEnd={handleEndVote} />
+          ))}
+        </div>
+
+        <section className="mt-8">
+          <div className="flex items-center justify-between">
+            <h2 className="text-[16px] font-semibold text-[#111827]">참여여부 투표</h2>
+            {!participationVote && (
+              <button
+                onClick={handleCreateParticipationVote}
+                className="rounded-full border border-[#2563EB] px-4 py-2 text-[12px] font-semibold text-[#2563EB]"
+              >
+                참여여부 투표 생성하기
+              </button>
+            )}
+          </div>
+
+          <div className="mt-4">
+            {participationVote ? (
+              <ParticipationVoteCard vote={participationVote} onEnd={handleEndParticipationVote} />
+            ) : (
+              <div className="rounded-[22px] border border-dashed border-[#CBD5F5] bg-[#F8FAFF] p-5 text-[13px] text-[#6B7280]">
+                참여여부 투표를 생성하면 참여 여부를 모을 수 있습니다.
+              </div>
+            )}
+          </div>
+
+          {participantCountText && <p className="mt-4 text-[13px] font-semibold text-[#1E3A8A]">{participantCountText}</p>}
+        </section>
+
+        {postDetail.isAuthor && (
+          <div className="mt-8 flex gap-3">
+            <button
+              onClick={() => navigate(`/meet/edit/${postDetail.id}`)}
+              className="flex-1 rounded-[24px] bg-[#2563EB] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:bg-[#1D4ED8]"
+            >
+              수정하기
+            </button>
+            <button
+              onClick={() => navigate(`/meet/delete/${postDetail.id}`)}
+              className="flex-1 rounded-[24px] bg-[#FF3B30] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:shadow-lg"
+            >
+              삭제하기
+            </button>
+          </div>
+        )}
+      </main>
+
+      <FooterNav />
+    </div>
   );
 };
 
-export default MeetDetail;
+export default PostDetailPage;

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -265,7 +265,7 @@ const ParticipationVoteCard: React.FC<{
 };
 
 const PostDetailPage: React.FC = () => {
-  const { meetId } = useParams();
+  const { postId } = useParams();
   const navigate = useNavigate();
 
   const [postDetail, setPostDetail] = useState<PostDetail | null>(null);
@@ -277,11 +277,11 @@ const PostDetailPage: React.FC = () => {
     let isMounted = true;
 
     const loadDetail = async () => {
-      if (!meetId) return;
+      if (!postId) return;
       setLoading(true);
 
       const [postResponse, voteResponse, participationResponse] = await Promise.all([
-        fetchPostDetail(meetId),
+        fetchPostDetail(postId),
         fetchVoteList(),
         fetchParticipationVote(),
       ]);
@@ -298,7 +298,7 @@ const PostDetailPage: React.FC = () => {
     return () => {
       isMounted = false;
     };
-  }, [meetId]);
+  }, [postId]);
 
   const handleEndVote = (voteId: string) => {
     setVotes((prev) =>

--- a/src/pages/PostList.tsx
+++ b/src/pages/PostList.tsx
@@ -3,26 +3,19 @@ import { Link, useNavigate } from "react-router-dom";
 import { server } from "@/utils/axios";
 import FooterNav from "../components/FooterNav";
 import calender from "../assets/img/calender.png";
+import { Post } from "@/types/Post";
 
-type MeetInfo = {
-  id: string;
-  title: string;
-  date: string | null;
-  place: string | null;
-  type?: string;
-};
-
-const MeetList: React.FC = () => {
-  const [meetList, setMeetList] = useState<MeetInfo[]>([]);
+const PostList: React.FC = () => {
+  const [postList, setPostList] = useState<Post[]>([]);
   const navigate = useNavigate();
-  const hasMeetings = useMemo(() => meetList.length > 0, [meetList]);
+  const hasPosts = useMemo(() => postList.length > 0, [postList]);
 
   useEffect(() => {
     const fetchMeetList = async () => {
         server
-          .get(`/meet/list`)
+          .get(`/post/list`)
           .then((response) => {
-            setMeetList(response.data);
+            setPostList(response.data);
           })
           .catch((error) => {
             console.error(error);
@@ -48,15 +41,15 @@ const MeetList: React.FC = () => {
 
         <section>
           <div className="mb-4 flex items-center justify-between text-[#8E8E93]">
-            <span className="text-[12px] font-medium">총 {meetList.length}개</span>
+            <span className="text-[12px] font-medium">총 {postList.length}개</span>
             <span className="text-[12px] font-medium">최신순</span>
           </div>
-          {hasMeetings ? (
+          {hasPosts ? (
             <ul className="flex flex-col gap-4">
-              {meetList.map((meet) => (
-                <li key={meet.id}>
+              {postList.map((post) => (
+                <li key={post.id}>
                   <Link
-                    to={`/meet/${meet.id}`}
+                    to={`/post/${post.id}`}
                     className="group flex w-full items-center justify-between gap-4 rounded-[22px] bg-white px-5 py-4 shadow-[0_8px_24px_rgba(26,26,26,0.08)] transition-all duration-200 hover:shadow-[0_12px_30px_rgba(26,26,26,0.12)]"
                   >
                     <div className="flex items-start gap-4">
@@ -69,28 +62,30 @@ const MeetList: React.FC = () => {
                       </span>
                       <div className="flex flex-col gap-1">
                         <div className="flex items-center gap-2">
-                          <span
-                            className={`rounded-full px-2 py-[2px] text-[11px] font-semibold ${
-                              meet.type === "travel"
-                                ? "bg-[#FEF3C7] text-[#92400E]"
-                                : "bg-[#E1F0FF] text-[#1E3A8A]"
-                            }`}
-                          >
-                            {meet.type === "travel" ? "여행" : "모임"}
-                          </span>
+                            <span
+                              className={`rounded-full px-2 py-[2px] text-[11px] font-semibold ${
+                                post.type === "travel"
+                                  ? "bg-[#FEF3C7] text-[#92400E]"
+                                  : "bg-[#E1F0FF] text-[#1E3A8A]"
+                              }`}
+                            >
+                              {post.type === "travel" ? "여행" : "회식"}
+                            </span>
+                        </div>
+                        <div className="flex items-center gap-2">
                           <h3 className="text-[15px] font-semibold text-[#1C1C1E] group-hover:text-[#5856D6]">
-                            {meet.title}
+                            {post.title}
                           </h3>
                         </div>
-                        <div className="flex flex-col text-[12px] text-[#8E8E93]">
+                        <div className="flex flex-col items-start text-[12px] text-[#8E8E93]">
                           <span>
-                            {meet.date && meet.date.trim().length > 0
-                              ? meet.date
+                            {post.date && post.date.value && post.date.value.trim().length > 0
+                              ? post.date.value
                               : "날짜 미정"}
                           </span>
                           <span>
-                            {meet.place && meet.place.trim().length > 0
-                              ? meet.place
+                            {post.place && post.place.value && post.place.value.trim().length > 0
+                              ? post.place.value
                               : "장소 미정"}
                           </span>
                         </div>
@@ -118,4 +113,4 @@ const MeetList: React.FC = () => {
   );
 };
 
-export default MeetList;
+export default PostList;


### PR DESCRIPTION
### Motivation
- Replace the old meet-focused detail screen with a post-centric detail view that supports multiple vote types and participation voting flows.
- Provide dummy API responses so UI behaviors for date/place/text votes and participation votes can be developed without backend endpoints.
- Display votes differently based on `activeYn` and `hasVoted` to show pre-vote, post-vote, and closed states.
- Add UI controls for adding votes, ending votes, creating participation votes, and showing participant counts when closed.

### Description
- Replaced the `MeetDetail` page with `PostDetailPage` and introduced dummy fetch functions `fetchPostDetail`, `fetchVoteList`, and `fetchParticipationVote` to load sample data.
- Added types `Vote`, `VoteOption`, and `ParticipationVote` and new components `VoteCard`, `ActiveVoteBefore`, `ActiveVoteAfter`, `ClosedVote`, `ParticipationVoteCard`, and `VoteOptionList` to render vote states and results.
- Implemented client-side handlers `handleAddVote`, `handleEndVote`, `handleCreateParticipationVote`, and `handleEndParticipationVote`, plus conditional author-only edit/delete buttons and vote list rendering.
- Kept the page integrated with routing and `FooterNav` and converted UI copy/messages to reflect post/vote semantics.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready, indicating the app served the bundle (succeeded).
- Attempted an automated Playwright screenshot run which failed with connection errors while trying to reach the dev server (failed).
- Performed an HTTP probe with `curl -I http://localhost:4173/post/1` which returned `200 OK` (succeeded).
- No automated unit or integration tests were executed against the new UI components.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69494a88889c8324bb81c56b1bbf58c0)