### PR TITLE
Refactor PostDetail vote UI and split per-type components

### DIFF
--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import type { Vote } from "../../types/vote";
+
+const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
+  <div className="mt-3 flex flex-col gap-2">
+    {options.map((option) => (
+      <div
+        key={option.id}
+        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium sm:text-sm ${
+          highlightVoted && option.voted
+            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+        }`}
+      >
+        <span>{option.label}</span>
+        <span className="text-[11px] font-semibold text-[#8E8E93] sm:text-xs">{option.count}표</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const DateVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
+  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
+    <div className="mt-3 flex flex-col gap-3">
+      {vote.options.map((option) => (
+        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
+          <input type="radio" name={`date-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
+          {option.label}
+        </label>
+      ))}
+    </div>
+    <button
+      type="button"
+      onClick={onVote}
+      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+    >
+      투표하기
+    </button>
+  </div>
+);
+
+export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void; onComplete: () => void }> = ({
+  vote,
+  onRevote,
+  onComplete,
+}) => (
+  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
+    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
+    <OptionResults options={vote.options} highlightVoted />
+    <div className="mt-4 grid grid-cols-2 gap-3">
+      <button
+        type="button"
+        onClick={onRevote}
+        className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#1C1C1E] transition hover:border-[#C7C7CC] sm:text-sm"
+      >
+        다시 투표하기
+      </button>
+      <button
+        type="button"
+        onClick={onComplete}
+        className="w-full rounded-[16px] bg-[#5856D6] px-5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+      >
+        투표하기
+      </button>
+    </div>
+  </div>
+);
+
+export const DateVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
+  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+    <p className="text-xs font-semibold text-[#4C4ACB]">투표 완료</p>
+    <OptionResults options={vote.options} highlightVoted />
+  </div>
+);

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import type { Vote } from "../../types/vote";
+
+const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
+  <div className="mt-3 flex flex-col gap-2">
+    {options.map((option) => (
+      <div
+        key={option.id}
+        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium sm:text-sm ${
+          highlightVoted && option.voted
+            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+        }`}
+      >
+        <span>{option.label}</span>
+        <span className="text-[11px] font-semibold text-[#8E8E93] sm:text-xs">{option.count}표</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const PlaceVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
+  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
+    <div className="mt-3 flex flex-col gap-3">
+      {vote.options.map((option) => (
+        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
+          <input type="radio" name={`place-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
+          {option.label}
+        </label>
+      ))}
+    </div>
+    <button
+      type="button"
+      onClick={onVote}
+      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+    >
+      투표하기
+    </button>
+  </div>
+);
+
+export const PlaceVoteAfter: React.FC<{ vote: Vote; onRevote: () => void; onComplete: () => void }> = ({
+  vote,
+  onRevote,
+  onComplete,
+}) => (
+  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
+    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
+    <OptionResults options={vote.options} highlightVoted />
+    <div className="mt-4 grid grid-cols-2 gap-3">
+      <button
+        type="button"
+        onClick={onRevote}
+        className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#1C1C1E] transition hover:border-[#C7C7CC] sm:text-sm"
+      >
+        다시 투표하기
+      </button>
+      <button
+        type="button"
+        onClick={onComplete}
+        className="w-full rounded-[16px] bg-[#5856D6] px-5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+      >
+        투표하기
+      </button>
+    </div>
+  </div>
+);
+
+export const PlaceVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
+  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+    <p className="text-xs font-semibold text-[#4C4ACB]">투표 완료</p>
+    <OptionResults options={vote.options} highlightVoted />
+  </div>
+);

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import type { Vote } from "../../types/vote";
+
+const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
+  <div className="mt-3 flex flex-col gap-2">
+    {options.map((option) => (
+      <div
+        key={option.id}
+        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium sm:text-sm ${
+          highlightVoted && option.voted
+            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+        }`}
+      >
+        <span>{option.label}</span>
+        <span className="text-[11px] font-semibold text-[#8E8E93] sm:text-xs">{option.count}표</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const TextVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
+  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
+    <div className="mt-3 flex flex-col gap-3">
+      {vote.options.map((option) => (
+        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
+          <input type="radio" name={`text-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
+          {option.label}
+        </label>
+      ))}
+    </div>
+    <button
+      type="button"
+      onClick={onVote}
+      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+    >
+      투표하기
+    </button>
+  </div>
+);
+
+export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void; onComplete: () => void }> = ({
+  vote,
+  onRevote,
+  onComplete,
+}) => (
+  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
+    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
+    <OptionResults options={vote.options} highlightVoted />
+    <div className="mt-4 grid grid-cols-2 gap-3">
+      <button
+        type="button"
+        onClick={onRevote}
+        className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#1C1C1E] transition hover:border-[#C7C7CC] sm:text-sm"
+      >
+        다시 투표하기
+      </button>
+      <button
+        type="button"
+        onClick={onComplete}
+        className="w-full rounded-[16px] bg-[#5856D6] px-5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+      >
+        투표하기
+      </button>
+    </div>
+  </div>
+);
+
+export const TextVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
+  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+    <p className="text-xs font-semibold text-[#4C4ACB]">투표 완료</p>
+    <OptionResults options={vote.options} highlightVoted />
+  </div>
+);

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import FooterNav from "../components/FooterNav";
+import { DateVoteAfter, DateVoteBefore, DateVoteComplete } from "../components/vote/DateVote";
+import { PlaceVoteAfter, PlaceVoteBefore, PlaceVoteComplete } from "../components/vote/PlaceVote";
+import { TextVoteAfter, TextVoteBefore, TextVoteComplete } from "../components/vote/TextVote";
+import type { Vote } from "../types/vote";
 
 type PostDetail = {
   id: string;
@@ -9,24 +13,6 @@ type PostDetail = {
   authorName: string;
   createdAt: string;
   isAuthor: boolean;
-};
-
-type VoteOption = {
-  id: string;
-  label: string;
-  count: number;
-  voted: boolean;
-};
-
-type VoteType = "date" | "place" | "text";
-
-type Vote = {
-  id: string;
-  title: string;
-  type: VoteType;
-  activeYn: "Y" | "N";
-  hasVoted: boolean;
-  options: VoteOption[];
 };
 
 type ParticipationVote = {
@@ -58,7 +44,7 @@ const fetchVoteList = async (): Promise<Vote[]> => {
       title: "회의 날짜 투표",
       type: "date",
       activeYn: "Y",
-      hasVoted: false,
+      status: "before",
       options: [
         { id: "d1", label: "5/25(토)", count: 4, voted: false },
         { id: "d2", label: "5/26(일)", count: 2, voted: false },
@@ -70,7 +56,7 @@ const fetchVoteList = async (): Promise<Vote[]> => {
       title: "회의 장소 투표",
       type: "place",
       activeYn: "Y",
-      hasVoted: true,
+      status: "after",
       options: [
         { id: "p1", label: "강남역 스터디룸", count: 5, voted: false },
         { id: "p2", label: "홍대 카페", count: 3, voted: true },
@@ -82,7 +68,7 @@ const fetchVoteList = async (): Promise<Vote[]> => {
       title: "공지용 메시지 톤 투표",
       type: "text",
       activeYn: "N",
-      hasVoted: true,
+      status: "complete",
       options: [
         { id: "t1", label: "포멀", count: 8, voted: true },
         { id: "t2", label: "캐주얼", count: 5, voted: false },
@@ -105,163 +91,9 @@ const fetchParticipationVote = async (): Promise<ParticipationVote | null> => {
 };
 
 const typeBadge = {
-  date: "bg-[#E0F2FE] text-[#0369A1]",
-  place: "bg-[#ECFDF3] text-[#047857]",
-  text: "bg-[#FEF3C7] text-[#92400E]",
-};
-
-const VoteOptionList: React.FC<{ options: VoteOption[]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
-  <div className="mt-4 flex flex-col gap-3">
-    {options.map((option) => (
-      <div
-        key={option.id}
-        className={`flex items-center justify-between rounded-2xl border px-4 py-3 text-[13px] font-medium transition ${
-          highlightVoted && option.voted
-            ? "border-[#1D4ED8] bg-[#EFF6FF] text-[#1E3A8A]"
-            : "border-[#E5E7EB] bg-white text-[#374151]"
-        }`}
-      >
-        <span>{option.label}</span>
-        <span className="text-[12px] font-semibold text-[#6B7280]">{option.count}표</span>
-      </div>
-    ))}
-  </div>
-);
-
-const ActiveVoteBefore: React.FC<{ vote: Vote }> = ({ vote }) => (
-  <div className="mt-4 rounded-2xl border border-dashed border-[#CBD5F5] bg-[#F8FAFF] p-4">
-    <p className="text-[13px] font-medium text-[#1E3A8A]">투표를 진행해주세요.</p>
-    <div className="mt-3 flex flex-col gap-3">
-      {vote.options.map((option) => (
-        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-[13px] text-[#374151]">
-          <input type="radio" name={`vote-${vote.id}`} className="h-4 w-4 text-[#2563EB]" />
-          {option.label}
-        </label>
-      ))}
-    </div>
-    <button className="mt-4 w-full rounded-2xl bg-[#2563EB] py-2 text-[13px] font-semibold text-white">투표하기</button>
-  </div>
-);
-
-const ActiveVoteAfter: React.FC<{ vote: Vote }> = ({ vote }) => (
-  <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F9FAFB] p-4">
-    <p className="text-[13px] font-medium text-[#111827]">내가 선택한 항목과 전체 결과</p>
-    <VoteOptionList options={vote.options} highlightVoted />
-  </div>
-);
-
-const ClosedVote: React.FC<{ vote: Vote }> = ({ vote }) => (
-  <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F3F4F6] p-4">
-    <p className="text-[13px] font-medium text-[#6B7280]">투표가 종료되었습니다.</p>
-    <VoteOptionList options={vote.options} />
-  </div>
-);
-
-const VoteCard: React.FC<{ vote: Vote; onEnd: (id: string) => void }> = ({ vote, onEnd }) => {
-  const typeLabel = vote.type === "date" ? "날짜" : vote.type === "place" ? "장소" : "텍스트";
-
-  return (
-    <div className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold ${typeBadge[vote.type]}`}>
-            {typeLabel} 투표
-          </span>
-          <h3 className="mt-2 text-[16px] font-semibold text-[#111827]">{vote.title}</h3>
-        </div>
-        <button
-          onClick={() => onEnd(vote.id)}
-          className="rounded-full border border-[#E5E7EB] px-3 py-1 text-[11px] font-semibold text-[#6B7280]"
-        >
-          투표 종료
-        </button>
-      </div>
-
-      {vote.activeYn === "Y" ? (vote.hasVoted ? <ActiveVoteAfter vote={vote} /> : <ActiveVoteBefore vote={vote} />) : <ClosedVote vote={vote} />}
-    </div>
-  );
-};
-
-const ParticipationVoteCard: React.FC<{
-  vote: ParticipationVote;
-  onEnd: () => void;
-}> = ({ vote, onEnd }) => {
-  if (vote.activeYn === "N") {
-    return (
-      <div className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
-        <div className="flex items-start justify-between">
-          <div>
-            <span className="inline-flex rounded-full bg-[#FEE2E2] px-3 py-1 text-[11px] font-semibold text-[#991B1B]">참여여부 투표 종료</span>
-            <h3 className="mt-2 text-[16px] font-semibold text-[#111827]">참여여부 결과</h3>
-          </div>
-          <button
-            onClick={onEnd}
-            className="rounded-full border border-[#E5E7EB] px-3 py-1 text-[11px] font-semibold text-[#6B7280]"
-          >
-            종료됨
-          </button>
-        </div>
-        <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F3F4F6] p-4">
-          <div className="flex justify-between text-[13px] text-[#374151]">
-            <span>참여</span>
-            <span className="font-semibold">{vote.yesCount}명</span>
-          </div>
-          <div className="mt-2 flex justify-between text-[13px] text-[#374151]">
-            <span>불참</span>
-            <span className="font-semibold">{vote.noCount}명</span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
-      <div className="flex items-start justify-between">
-        <div>
-          <span className="inline-flex rounded-full bg-[#DBEAFE] px-3 py-1 text-[11px] font-semibold text-[#1D4ED8]">참여여부 투표</span>
-          <h3 className="mt-2 text-[16px] font-semibold text-[#111827]">참여 가능 여부</h3>
-        </div>
-        <button
-          onClick={onEnd}
-          className="rounded-full border border-[#E5E7EB] px-3 py-1 text-[11px] font-semibold text-[#6B7280]"
-        >
-          투표 종료
-        </button>
-      </div>
-
-      {vote.hasVoted ? (
-        <div className="mt-4 rounded-2xl border border-[#E5E7EB] bg-[#F9FAFB] p-4">
-          <p className="text-[13px] font-medium text-[#111827]">내가 선택한 항목과 전체 결과</p>
-          <div className="mt-3 flex flex-col gap-2 text-[13px] text-[#374151]">
-            <div className="flex justify-between">
-              <span>참여</span>
-              <span className="font-semibold">{vote.yesCount}명</span>
-            </div>
-            <div className="flex justify-between">
-              <span>불참</span>
-              <span className="font-semibold">{vote.noCount}명</span>
-            </div>
-          </div>
-        </div>
-      ) : (
-        <div className="mt-4 rounded-2xl border border-dashed border-[#CBD5F5] bg-[#F8FAFF] p-4">
-          <p className="text-[13px] font-medium text-[#1E3A8A]">참여 여부를 선택해주세요.</p>
-          <div className="mt-3 flex flex-col gap-3">
-            <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-[13px] text-[#374151]">
-              <input type="radio" name="participation" className="h-4 w-4 text-[#2563EB]" />
-              참여
-            </label>
-            <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-[13px] text-[#374151]">
-              <input type="radio" name="participation" className="h-4 w-4 text-[#2563EB]" />
-              불참
-            </label>
-          </div>
-          <button className="mt-4 w-full rounded-2xl bg-[#2563EB] py-2 text-[13px] font-semibold text-white">투표하기</button>
-        </div>
-      )}
-    </div>
-  );
+  date: "bg-[#E1F0FF] text-[#1E3A8A]",
+  place: "bg-[#E7F7EE] text-[#047857]",
+  text: "bg-[#FFF6D7] text-[#92400E]",
 };
 
 const PostDetailPage: React.FC = () => {
@@ -313,6 +145,45 @@ const PostDetailPage: React.FC = () => {
     );
   };
 
+  const handleVote = (voteId: string) => {
+    setVotes((prev) =>
+      prev.map((vote) =>
+        vote.id === voteId
+          ? {
+              ...vote,
+              status: "after",
+            }
+          : vote,
+      ),
+    );
+  };
+
+  const handleRevote = (voteId: string) => {
+    setVotes((prev) =>
+      prev.map((vote) =>
+        vote.id === voteId
+          ? {
+              ...vote,
+              status: "before",
+            }
+          : vote,
+      ),
+    );
+  };
+
+  const handleCompleteVote = (voteId: string) => {
+    setVotes((prev) =>
+      prev.map((vote) =>
+        vote.id === voteId
+          ? {
+              ...vote,
+              status: "complete",
+            }
+          : vote,
+      ),
+    );
+  };
+
   const handleAddVote = () => {
     setVotes((prev) => [
       {
@@ -320,7 +191,7 @@ const PostDetailPage: React.FC = () => {
         title: "새로운 투표",
         type: "text",
         activeYn: "Y",
-        hasVoted: false,
+        status: "before",
         options: [
           { id: "new-1", label: "옵션 1", count: 0, voted: false },
           { id: "new-2", label: "옵션 2", count: 0, voted: false },
@@ -358,10 +229,50 @@ const PostDetailPage: React.FC = () => {
     return `참여 인원: ${participationVote.participantCount}명`;
   }, [participationVote]);
 
+  const renderClosedVote = (vote: Vote) => (
+    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+      <p className="text-xs font-semibold text-[#8E8E93]">투표 종료</p>
+      <div className="mt-3 flex flex-col gap-2 text-xs text-[#1C1C1E] sm:text-sm">
+        {vote.options.map((option) => (
+          <div key={option.id} className="flex items-center justify-between">
+            <span>{option.label}</span>
+            <span className="font-semibold text-[#8E8E93]">{option.count}표</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  const renderVoteState = (vote: Vote) => {
+    if (vote.activeYn === "N") {
+      return renderClosedVote(vote);
+    }
+
+    const onVote = () => handleVote(vote.id);
+    const onRevote = () => handleRevote(vote.id);
+    const onComplete = () => handleCompleteVote(vote.id);
+
+    if (vote.type === "date") {
+      if (vote.status === "before") return <DateVoteBefore vote={vote} onVote={onVote} />;
+      if (vote.status === "after") return <DateVoteAfter vote={vote} onRevote={onRevote} onComplete={onComplete} />;
+      return <DateVoteComplete vote={vote} />;
+    }
+
+    if (vote.type === "place") {
+      if (vote.status === "before") return <PlaceVoteBefore vote={vote} onVote={onVote} />;
+      if (vote.status === "after") return <PlaceVoteAfter vote={vote} onRevote={onRevote} onComplete={onComplete} />;
+      return <PlaceVoteComplete vote={vote} />;
+    }
+
+    if (vote.status === "before") return <TextVoteBefore vote={vote} onVote={onVote} />;
+    if (vote.status === "after") return <TextVoteAfter vote={vote} onRevote={onRevote} onComplete={onComplete} />;
+    return <TextVoteComplete vote={vote} />;
+  };
+
   if (loading) {
     return (
-      <div className="min-h-screen w-full flex flex-col items-center justify-center bg-[#F2F2F7]">
-        <div className="h-14 w-14 animate-spin rounded-full border-4 border-[#E5E5EA] border-t-[#1E3A8A]" />
+      <div className="flex min-h-screen w-full flex-col items-center justify-center bg-[#F2F2F7]">
+        <div className="h-14 w-14 animate-spin rounded-full border-4 border-[#E5E5EA] border-t-[#5856D6]" />
         <p className="mt-4 text-[13px] text-[#8E8E93]">게시글 정보를 불러오는 중입니다...</p>
       </div>
     );
@@ -369,11 +280,11 @@ const PostDetailPage: React.FC = () => {
 
   if (!postDetail) {
     return (
-      <div className="min-h-screen w-full flex flex-col items-center justify-center bg-[#F2F2F7] text-center">
+      <div className="flex min-h-screen w-full flex-col items-center justify-center bg-[#F2F2F7] text-center">
         <p className="text-[14px] font-medium text-[#1C1C1E]">게시글 정보를 불러오지 못했습니다.</p>
         <button
           onClick={() => navigate(-1)}
-          className="mt-4 rounded-full bg-[#1E3A8A] px-5 py-2 text-[12px] font-semibold text-white shadow-md"
+          className="mt-4 rounded-[16px] bg-[#5856D6] px-5 py-2 text-xs font-semibold text-white shadow-sm"
         >
           이전 페이지로 돌아가기
         </button>
@@ -382,81 +293,171 @@ const PostDetailPage: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen w-full bg-[#F2F2F7] pb-[90px]">
-      <header className="bg-white px-6 pt-6 pb-5 shadow-[0_6px_20px_rgba(0,0,0,0.05)]">
-        <span className="rounded-full bg-[#E1F0FF] px-3 py-1 text-[11px] font-semibold tracking-wide text-[#1E3A8A]">게시글 상세</span>
-        <h1 className="mt-3 text-[23px] font-bold leading-tight text-[#111827]">{postDetail.title}</h1>
-        <div className="mt-2 flex items-center gap-2 text-[12px] text-[#6B7280]">
-          <span>{postDetail.authorName}</span>
-          <span>•</span>
-          <span>{postDetail.createdAt}</span>
-        </div>
-        <p className="mt-3 text-[14px] text-[#374151]">{postDetail.content}</p>
-      </header>
-
-      <main className="px-6 pt-6">
-        <section className="rounded-[22px] bg-white p-5 shadow-[0_12px_32px_rgba(26,26,26,0.08)]">
-          <div className="flex items-center justify-between">
-            <h2 className="text-[16px] font-semibold text-[#111827]">투표 리스트</h2>
-            <button
-              onClick={handleAddVote}
-              className="rounded-full bg-[#2563EB] px-4 py-2 text-[12px] font-semibold text-white"
-            >
-              투표 추가
-            </button>
+    <div className="min-h-screen w-full bg-[#F2F2F7]">
+      <div className="mx-auto flex w-full max-w-screen-sm flex-col gap-6 px-4 pb-24 pt-8 sm:max-w-screen-md sm:px-6 sm:pb-28 lg:max-w-4xl">
+        <header className="rounded-[24px] bg-white p-6 shadow-sm">
+          <span className="rounded-full bg-[#E1F0FF] px-3 py-1 text-[11px] font-semibold tracking-wide text-[#1E3A8A]">
+            게시글 상세
+          </span>
+          <h1 className="mt-4 text-left text-2xl font-bold text-[#1C1C1E] sm:text-3xl">{postDetail.title}</h1>
+          <div className="mt-2 flex items-center gap-2 text-xs text-[#8E8E93] sm:text-sm">
+            <span>{postDetail.authorName}</span>
+            <span>•</span>
+            <span>{postDetail.createdAt}</span>
           </div>
-          <p className="mt-2 text-[12px] text-[#6B7280]">투표는 진행중 여부에 따라 다른 컴포넌트로 표시됩니다.</p>
+          <p className="mt-4 text-sm text-[#1C1C1E] sm:text-base">{postDetail.content}</p>
+        </header>
+
+        <section className="space-y-4">
+          <div className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-[#1C1C1E]">투표 리스트</h2>
+                <p className="mt-1 text-xs text-[#8E8E93] sm:text-sm">투표 진행 상태에 따라 화면이 변경됩니다.</p>
+              </div>
+              <button
+                onClick={handleAddVote}
+                className="rounded-[16px] bg-[#5856D6] px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+              >
+                투표 추가
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-5">
+            {votes.map((vote) => {
+              const typeLabel = vote.type === "date" ? "날짜" : vote.type === "place" ? "장소" : "텍스트";
+
+              return (
+                <div key={vote.id} className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold ${typeBadge[vote.type]}`}>
+                        {typeLabel} 투표
+                      </span>
+                      <h3 className="mt-3 text-lg font-semibold text-[#1C1C1E]">{vote.title}</h3>
+                    </div>
+                    <button
+                      onClick={() => handleEndVote(vote.id)}
+                      className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
+                    >
+                      투표 종료
+                    </button>
+                  </div>
+
+                  {renderVoteState(vote)}
+                </div>
+              );
+            })}
+          </div>
         </section>
 
-        <div className="mt-5 flex flex-col gap-5">
-          {votes.map((vote) => (
-            <VoteCard key={vote.id} vote={vote} onEnd={handleEndVote} />
-          ))}
-        </div>
-
-        <section className="mt-8">
+        <section className="space-y-4">
           <div className="flex items-center justify-between">
-            <h2 className="text-[16px] font-semibold text-[#111827]">참여여부 투표</h2>
+            <h2 className="text-lg font-semibold text-[#1C1C1E]">참여여부 투표</h2>
             {!participationVote && (
               <button
                 onClick={handleCreateParticipationVote}
-                className="rounded-full border border-[#2563EB] px-4 py-2 text-[12px] font-semibold text-[#2563EB]"
+                className="rounded-[16px] border border-[#5856D6] px-4 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#4C4ACB] sm:text-sm"
               >
                 참여여부 투표 생성하기
               </button>
             )}
           </div>
 
-          <div className="mt-4">
+          <div>
             {participationVote ? (
-              <ParticipationVoteCard vote={participationVote} onEnd={handleEndParticipationVote} />
+              <div className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
+                <div className="flex items-start justify-between">
+                  <div>
+                    <span
+                      className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold ${
+                        participationVote.activeYn === "N" ? "bg-[#FEE2E2] text-[#991B1B]" : "bg-[#E1F0FF] text-[#1E3A8A]"
+                      }`}
+                    >
+                      {participationVote.activeYn === "N" ? "참여여부 투표 종료" : "참여여부 투표"}
+                    </span>
+                    <h3 className="mt-3 text-lg font-semibold text-[#1C1C1E]">참여 가능 여부</h3>
+                  </div>
+                  <button
+                    onClick={handleEndParticipationVote}
+                    className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
+                  >
+                    {participationVote.activeYn === "N" ? "종료됨" : "투표 종료"}
+                  </button>
+                </div>
+
+                {participationVote.activeYn === "N" ? (
+                  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+                    <div className="flex justify-between text-xs text-[#1C1C1E] sm:text-sm">
+                      <span>참여</span>
+                      <span className="font-semibold">{participationVote.yesCount}명</span>
+                    </div>
+                    <div className="mt-2 flex justify-between text-xs text-[#1C1C1E] sm:text-sm">
+                      <span>불참</span>
+                      <span className="font-semibold">{participationVote.noCount}명</span>
+                    </div>
+                  </div>
+                ) : participationVote.hasVoted ? (
+                  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
+                    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
+                    <div className="mt-3 flex flex-col gap-2 text-xs text-[#1C1C1E] sm:text-sm">
+                      <div className="flex justify-between">
+                        <span>참여</span>
+                        <span className="font-semibold">{participationVote.yesCount}명</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>불참</span>
+                        <span className="font-semibold">{participationVote.noCount}명</span>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+                    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
+                    <div className="mt-3 flex flex-col gap-3">
+                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
+                        <input type="radio" name="participation" className="h-4 w-4 text-[#5856D6]" />
+                        참여
+                      </label>
+                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
+                        <input type="radio" name="participation" className="h-4 w-4 text-[#5856D6]" />
+                        불참
+                      </label>
+                    </div>
+                    <button className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm">
+                      투표하기
+                    </button>
+                  </div>
+                )}
+              </div>
             ) : (
-              <div className="rounded-[22px] border border-dashed border-[#CBD5F5] bg-[#F8FAFF] p-5 text-[13px] text-[#6B7280]">
+              <div className="rounded-[24px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-5 text-xs text-[#8E8E93] sm:text-sm">
                 참여여부 투표를 생성하면 참여 여부를 모을 수 있습니다.
               </div>
             )}
           </div>
 
-          {participantCountText && <p className="mt-4 text-[13px] font-semibold text-[#1E3A8A]">{participantCountText}</p>}
+          {participantCountText && <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>}
         </section>
 
         {postDetail.isAuthor && (
-          <div className="mt-8 flex gap-3">
+          <div className="grid grid-cols-2 gap-3">
             <button
               onClick={() => navigate(`/meet/edit/${postDetail.id}`)}
-              className="flex-1 rounded-[24px] bg-[#2563EB] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:bg-[#1D4ED8]"
+              className="w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
             >
               수정하기
             </button>
             <button
               onClick={() => navigate(`/meet/delete/${postDetail.id}`)}
-              className="flex-1 rounded-[24px] bg-[#FF3B30] px-4 py-3 text-[14px] font-semibold text-white shadow-md transition hover:shadow-lg"
+              className="w-full rounded-[16px] bg-[#FF3B30] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#e1342b] sm:text-sm"
             >
               삭제하기
             </button>
           </div>
         )}
-      </main>
+      </div>
 
       <FooterNav />
     </div>

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -1,0 +1,19 @@
+export type VoteOption = {
+  id: string;
+  label: string;
+  count: number;
+  voted: boolean;
+};
+
+export type VoteType = "date" | "place" | "text";
+
+export type VoteStatus = "before" | "after" | "complete";
+
+export type Vote = {
+  id: string;
+  title: string;
+  type: VoteType;
+  activeYn: "Y" | "N";
+  status: VoteStatus;
+  options: VoteOption[];
+};


### PR DESCRIPTION
### Motivation
- Align `PostDetail` vote UI with the 회식 투표 생성 design and improve consistency across vote screens.
- Separate vote state UIs by vote type so date/place/text flows can be maintained independently.
- Support explicit before/after/complete states and simple closed-state rendering per requirements.
- Make vote interactions predictable: `투표하기` advances state to after/complete and `다시 투표하기` returns to before.

### Description
- Added `src/types/vote.ts` defining `Vote`, `VoteStatus`, `VoteType`, and `VoteOption` types.
- Introduced three new components under `src/components/vote/`: `DateVote.tsx`, `PlaceVote.tsx`, and `TextVote.tsx`, each exporting `Before/After/Complete` subcomponents.
- Reworked `src/pages/PostDetail.tsx` to use the new types and components, added handlers `handleVote`, `handleRevote`, and `handleCompleteVote`, and simplified closed vote rendering to only show title and results.
- Updated layout and styling in `PostDetail` to match the MeetVote design language and adjusted participation-vote presentation.

### Testing
- Started the dev server with `npm run dev` which reported Vite ready (server started successfully).
- Attempted a Playwright screenshot of `http://localhost:4173/post/1` which failed with `net::ERR_CONNECTION_REFUSED` (browser run failed).
- Verified a direct HTTP check with `curl -I http://localhost:4173/post/1` returned `HTTP/1.1 200 OK` (endpoint served HTML).
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949530fb3b4832498bfb14d9ced8440)