### PR TITLE
PostDetail: mobile-first voting UI & member popups

### DIFF
--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -1,19 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
 import type { Vote } from "../../types/vote";
+import VotedMemberList from "../popUp/VotedMemberList";
 
 const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
   <div className="mt-3 flex flex-col gap-2">
     {options.map((option) => (
       <div
         key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium sm:text-sm ${
+        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
           highlightVoted && option.voted
             ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
         }`}
       >
-        <span>{option.label}</span>
-        <span className="text-[11px] font-semibold text-[#8E8E93] sm:text-xs">{option.count}표</span>
+        <div className="flex items-center gap-2">
+          <span>{option.label}</span>
+          {highlightVoted && option.voted && (
+            <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
+              내가 투표함
+            </span>
+          )}
+        </div>
+        <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
       </div>
     ))}
   </div>
@@ -21,55 +29,87 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
 
 export const DateVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
   <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
     <div className="mt-3 flex flex-col gap-3">
       {vote.options.map((option) => (
-        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
+        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
           <input type="radio" name={`date-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
           {option.label}
         </label>
       ))}
     </div>
+    <div className="mt-4 rounded-xl bg-white px-4 py-3">
+      <label className="text-[11px] font-semibold text-[#8E8E93]">날짜 추가</label>
+      <input
+        type="date"
+        className="mt-2 w-full rounded-lg border border-[#E5E5EA] px-3 py-2 text-xs text-[#1C1C1E]"
+      />
+      <button
+        type="button"
+        className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+      >
+        항목 추가하기
+      </button>
+    </div>
     <button
       type="button"
       onClick={onVote}
-      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
     >
       투표하기
     </button>
   </div>
 );
 
-export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void; onComplete: () => void }> = ({
-  vote,
-  onRevote,
-  onComplete,
-}) => (
-  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
-    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
-    <OptionResults options={vote.options} highlightVoted />
-    <div className="mt-4 grid grid-cols-2 gap-3">
-      <button
-        type="button"
-        onClick={onRevote}
-        className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#1C1C1E] transition hover:border-[#C7C7CC] sm:text-sm"
-      >
-        다시 투표하기
-      </button>
-      <button
-        type="button"
-        onClick={onComplete}
-        className="w-full rounded-[16px] bg-[#5856D6] px-5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
-      >
-        투표하기
-      </button>
+export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ vote, onRevote }) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+  const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
+      <div className="mt-2 flex flex-col gap-2">
+        {vote.options.map((option) => (
+          <div
+            key={option.id}
+            className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
+              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <span>{option.label}</span>
+              {option.voted && (
+                <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
+                  내가 투표함
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              className="text-[11px] font-semibold text-[#5856D6]"
+              onClick={() => setSelectedOptionId(option.id)}
+            >
+              {option.count}명
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4">
+        <button
+          type="button"
+          onClick={onRevote}
+          className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+        >
+          다시 투표하기
+        </button>
+      </div>
+      {selectedOption && (
+        <VotedMemberList selectedItem={{ memberList: selectedOption.memberList ?? [] }} closePopup={() => setSelectedOptionId(null)} />
+      )}
     </div>
-  </div>
-);
+  );
+};
 
 export const DateVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
   <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-    <p className="text-xs font-semibold text-[#4C4ACB]">투표 완료</p>
     <OptionResults options={vote.options} highlightVoted />
   </div>
 );

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -1,75 +1,130 @@
-import React from "react";
+import React, { useState } from "react";
 import type { Vote } from "../../types/vote";
+import VotedMemberList from "../popUp/VotedMemberList";
+import SearchPopup from "../popUp/PlaceSearch";
 
 const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
   <div className="mt-3 flex flex-col gap-2">
     {options.map((option) => (
       <div
         key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium sm:text-sm ${
+        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
           highlightVoted && option.voted
             ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
         }`}
       >
-        <span>{option.label}</span>
-        <span className="text-[11px] font-semibold text-[#8E8E93] sm:text-xs">{option.count}표</span>
+        <div className="flex items-center gap-2">
+          <span>{option.label}</span>
+          {highlightVoted && option.voted && (
+            <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
+              내가 투표함
+            </span>
+          )}
+        </div>
+        <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
       </div>
     ))}
   </div>
 );
 
-export const PlaceVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
-  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
-    <div className="mt-3 flex flex-col gap-3">
-      {vote.options.map((option) => (
-        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
-          <input type="radio" name={`place-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
-          {option.label}
-        </label>
-      ))}
-    </div>
-    <button
-      type="button"
-      onClick={onVote}
-      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
-    >
-      투표하기
-    </button>
-  </div>
-);
+export const PlaceVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => {
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [selectedPlace, setSelectedPlace] = useState<string>("");
 
-export const PlaceVoteAfter: React.FC<{ vote: Vote; onRevote: () => void; onComplete: () => void }> = ({
-  vote,
-  onRevote,
-  onComplete,
-}) => (
-  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
-    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
-    <OptionResults options={vote.options} highlightVoted />
-    <div className="mt-4 grid grid-cols-2 gap-3">
+  const handlePopupSelect = (location: { x: string; y: string; address: string }) => {
+    setSelectedPlace(location.address);
+    setIsPopupOpen(false);
+  };
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+      <div className="mt-3 flex flex-col gap-3">
+        {vote.options.map((option) => (
+          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+            <input type="radio" name={`place-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
+            {option.label}
+          </label>
+        ))}
+      </div>
+      <div className="mt-4 rounded-xl bg-white px-4 py-3">
+        <label className="text-[11px] font-semibold text-[#8E8E93]">장소 추가</label>
+        <button
+          type="button"
+          className="mt-2 w-full rounded-lg border border-[#E5E5EA] px-3 py-2 text-left text-xs text-[#5856D6]"
+          onClick={() => setIsPopupOpen(true)}
+        >
+          {selectedPlace || "장소를 선택하세요"}
+        </button>
+        <button
+          type="button"
+          className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+        >
+          항목 추가하기
+        </button>
+      </div>
       <button
         type="button"
-        onClick={onRevote}
-        className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#1C1C1E] transition hover:border-[#C7C7CC] sm:text-sm"
-      >
-        다시 투표하기
-      </button>
-      <button
-        type="button"
-        onClick={onComplete}
-        className="w-full rounded-[16px] bg-[#5856D6] px-5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+        onClick={onVote}
+        className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
       >
         투표하기
       </button>
+      <SearchPopup isOpen={isPopupOpen} onClose={() => setIsPopupOpen(false)} onSelect={handlePopupSelect} />
     </div>
-  </div>
-);
+  );
+};
+
+export const PlaceVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ vote, onRevote }) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+  const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
+      <div className="mt-2 flex flex-col gap-2">
+        {vote.options.map((option) => (
+          <div
+            key={option.id}
+            className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
+              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <span>{option.label}</span>
+              {option.voted && (
+                <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
+                  내가 투표함
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              className="text-[11px] font-semibold text-[#5856D6]"
+              onClick={() => setSelectedOptionId(option.id)}
+            >
+              {option.count}명
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4">
+        <button
+          type="button"
+          onClick={onRevote}
+          className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+        >
+          다시 투표하기
+        </button>
+      </div>
+      {selectedOption && (
+        <VotedMemberList selectedItem={{ memberList: selectedOption.memberList ?? [] }} closePopup={() => setSelectedOptionId(null)} />
+      )}
+    </div>
+  );
+};
 
 export const PlaceVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
   <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-    <p className="text-xs font-semibold text-[#4C4ACB]">투표 완료</p>
     <OptionResults options={vote.options} highlightVoted />
   </div>
 );

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -1,19 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
 import type { Vote } from "../../types/vote";
+import VotedMemberList from "../popUp/VotedMemberList";
 
 const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
   <div className="mt-3 flex flex-col gap-2">
     {options.map((option) => (
       <div
         key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium sm:text-sm ${
+        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
           highlightVoted && option.voted
             ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
         }`}
       >
-        <span>{option.label}</span>
-        <span className="text-[11px] font-semibold text-[#8E8E93] sm:text-xs">{option.count}표</span>
+        <div className="flex items-center gap-2">
+          <span>{option.label}</span>
+          {highlightVoted && option.voted && (
+            <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
+              내가 투표함
+            </span>
+          )}
+        </div>
+        <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
       </div>
     ))}
   </div>
@@ -21,55 +29,88 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
 
 export const TextVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
   <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
     <div className="mt-3 flex flex-col gap-3">
       {vote.options.map((option) => (
-        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
+        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
           <input type="radio" name={`text-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
           {option.label}
         </label>
       ))}
     </div>
+    <div className="mt-4 rounded-xl bg-white px-4 py-3">
+      <label className="text-[11px] font-semibold text-[#8E8E93]">텍스트 추가</label>
+      <input
+        type="text"
+        placeholder="텍스트 입력"
+        className="mt-2 w-full rounded-lg border border-[#E5E5EA] px-3 py-2 text-xs text-[#1C1C1E]"
+      />
+      <button
+        type="button"
+        className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+      >
+        항목 추가하기
+      </button>
+    </div>
     <button
       type="button"
       onClick={onVote}
-      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
     >
       투표하기
     </button>
   </div>
 );
 
-export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void; onComplete: () => void }> = ({
-  vote,
-  onRevote,
-  onComplete,
-}) => (
-  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
-    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
-    <OptionResults options={vote.options} highlightVoted />
-    <div className="mt-4 grid grid-cols-2 gap-3">
-      <button
-        type="button"
-        onClick={onRevote}
-        className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#1C1C1E] transition hover:border-[#C7C7CC] sm:text-sm"
-      >
-        다시 투표하기
-      </button>
-      <button
-        type="button"
-        onClick={onComplete}
-        className="w-full rounded-[16px] bg-[#5856D6] px-5 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
-      >
-        투표하기
-      </button>
+export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ vote, onRevote }) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+  const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
+      <div className="mt-2 flex flex-col gap-2">
+        {vote.options.map((option) => (
+          <div
+            key={option.id}
+            className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
+              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <span>{option.label}</span>
+              {option.voted && (
+                <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
+                  내가 투표함
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              className="text-[11px] font-semibold text-[#5856D6]"
+              onClick={() => setSelectedOptionId(option.id)}
+            >
+              {option.count}명
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4">
+        <button
+          type="button"
+          onClick={onRevote}
+          className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+        >
+          다시 투표하기
+        </button>
+      </div>
+      {selectedOption && (
+        <VotedMemberList selectedItem={{ memberList: selectedOption.memberList ?? [] }} closePopup={() => setSelectedOptionId(null)} />
+      )}
     </div>
-  </div>
-);
+  );
+};
 
 export const TextVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
   <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-    <p className="text-xs font-semibold text-[#4C4ACB]">투표 완료</p>
     <OptionResults options={vote.options} highlightVoted />
   </div>
 );

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -46,9 +46,21 @@ const fetchVoteList = async (): Promise<Vote[]> => {
       activeYn: "Y",
       status: "before",
       options: [
-        { id: "d1", label: "5/25(토)", count: 4, voted: false },
-        { id: "d2", label: "5/26(일)", count: 2, voted: false },
-        { id: "d3", label: "5/27(월)", count: 6, voted: false },
+        {
+          id: "d1",
+          label: "5/25(토)",
+          count: 4,
+          voted: false,
+          memberList: [{ name: "지민" }, { name: "서연" }, { name: "태호" }, { name: "윤아" }],
+        },
+        { id: "d2", label: "5/26(일)", count: 2, voted: false, memberList: [{ name: "도현" }, { name: "현수" }] },
+        {
+          id: "d3",
+          label: "5/27(월)",
+          count: 6,
+          voted: false,
+          memberList: [{ name: "소영" }, { name: "민재" }, { name: "지원" }, { name: "민호" }, { name: "유진" }, { name: "가영" }],
+        },
       ],
     },
     {
@@ -58,9 +70,15 @@ const fetchVoteList = async (): Promise<Vote[]> => {
       activeYn: "Y",
       status: "after",
       options: [
-        { id: "p1", label: "강남역 스터디룸", count: 5, voted: false },
-        { id: "p2", label: "홍대 카페", count: 3, voted: true },
-        { id: "p3", label: "온라인", count: 4, voted: false },
+        {
+          id: "p1",
+          label: "강남역 스터디룸",
+          count: 5,
+          voted: false,
+          memberList: [{ name: "지민" }, { name: "서연" }, { name: "도현" }, { name: "현수" }, { name: "유진" }],
+        },
+        { id: "p2", label: "홍대 카페", count: 3, voted: true, memberList: [{ name: "태호" }, { name: "지원" }, { name: "윤아" }] },
+        { id: "p3", label: "온라인", count: 4, voted: false, memberList: [{ name: "민재" }, { name: "민호" }, { name: "가영" }, { name: "소영" }] },
       ],
     },
     {
@@ -70,9 +88,24 @@ const fetchVoteList = async (): Promise<Vote[]> => {
       activeYn: "N",
       status: "complete",
       options: [
-        { id: "t1", label: "포멀", count: 8, voted: true },
-        { id: "t2", label: "캐주얼", count: 5, voted: false },
-        { id: "t3", label: "친근함", count: 2, voted: false },
+        {
+          id: "t1",
+          label: "포멀",
+          count: 8,
+          voted: true,
+          memberList: [
+            { name: "지민" },
+            { name: "서연" },
+            { name: "태호" },
+            { name: "윤아" },
+            { name: "민재" },
+            { name: "현수" },
+            { name: "지원" },
+            { name: "소영" },
+          ],
+        },
+        { id: "t2", label: "캐주얼", count: 5, voted: false, memberList: [{ name: "도현" }, { name: "유진" }, { name: "민호" }, { name: "가영" }, { name: "지아" }] },
+        { id: "t3", label: "친근함", count: 2, voted: false, memberList: [{ name: "다은" }, { name: "세진" }] },
       ],
     },
   ];
@@ -90,12 +123,6 @@ const fetchParticipationVote = async (): Promise<ParticipationVote | null> => {
   };
 };
 
-const typeBadge = {
-  date: "bg-[#E1F0FF] text-[#1E3A8A]",
-  place: "bg-[#E7F7EE] text-[#047857]",
-  text: "bg-[#FFF6D7] text-[#92400E]",
-};
-
 const PostDetailPage: React.FC = () => {
   const { postId } = useParams();
   const navigate = useNavigate();
@@ -103,6 +130,7 @@ const PostDetailPage: React.FC = () => {
   const [postDetail, setPostDetail] = useState<PostDetail | null>(null);
   const [votes, setVotes] = useState<Vote[]>([]);
   const [participationVote, setParticipationVote] = useState<ParticipationVote | null>(null);
+  const [participationChoice, setParticipationChoice] = useState<"yes" | "no" | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -171,19 +199,6 @@ const PostDetailPage: React.FC = () => {
     );
   };
 
-  const handleCompleteVote = (voteId: string) => {
-    setVotes((prev) =>
-      prev.map((vote) =>
-        vote.id === voteId
-          ? {
-              ...vote,
-              status: "complete",
-            }
-          : vote,
-      ),
-    );
-  };
-
   const handleAddVote = () => {
     setVotes((prev) => [
       {
@@ -193,8 +208,8 @@ const PostDetailPage: React.FC = () => {
         activeYn: "Y",
         status: "before",
         options: [
-          { id: "new-1", label: "옵션 1", count: 0, voted: false },
-          { id: "new-2", label: "옵션 2", count: 0, voted: false },
+          { id: "new-1", label: "옵션 1", count: 0, voted: false, memberList: [] },
+          { id: "new-2", label: "옵션 2", count: 0, voted: false, memberList: [] },
         ],
       },
       ...prev,
@@ -224,22 +239,33 @@ const PostDetailPage: React.FC = () => {
     );
   };
 
+  const handleParticipationVote = () => {
+    if (!participationVote || !participationChoice) return;
+    setParticipationVote((prev) =>
+      prev
+        ? {
+            ...prev,
+            hasVoted: true,
+            yesCount: participationChoice === "yes" ? prev.yesCount + 1 : prev.yesCount,
+            noCount: participationChoice === "no" ? prev.noCount + 1 : prev.noCount,
+          }
+        : prev,
+    );
+  };
+
   const participantCountText = useMemo(() => {
     if (!participationVote || participationVote.activeYn !== "N") return null;
     return `참여 인원: ${participationVote.participantCount}명`;
   }, [participationVote]);
 
   const renderClosedVote = (vote: Vote) => (
-    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-      <p className="text-xs font-semibold text-[#8E8E93]">투표 종료</p>
-      <div className="mt-3 flex flex-col gap-2 text-xs text-[#1C1C1E] sm:text-sm">
-        {vote.options.map((option) => (
-          <div key={option.id} className="flex items-center justify-between">
-            <span>{option.label}</span>
-            <span className="font-semibold text-[#8E8E93]">{option.count}표</span>
-          </div>
-        ))}
-      </div>
+    <div className="mt-3 rounded-[16px] bg-[#F9F9FB] p-4 text-xs text-[#1C1C1E]">
+      {vote.options.map((option) => (
+        <p key={option.id} className="flex items-center justify-between py-1">
+          <span>{option.label}</span>
+          <span className="font-semibold text-[#8E8E93]">{option.count}표</span>
+        </p>
+      ))}
     </div>
   );
 
@@ -250,22 +276,20 @@ const PostDetailPage: React.FC = () => {
 
     const onVote = () => handleVote(vote.id);
     const onRevote = () => handleRevote(vote.id);
-    const onComplete = () => handleCompleteVote(vote.id);
-
     if (vote.type === "date") {
       if (vote.status === "before") return <DateVoteBefore vote={vote} onVote={onVote} />;
-      if (vote.status === "after") return <DateVoteAfter vote={vote} onRevote={onRevote} onComplete={onComplete} />;
+      if (vote.status === "after") return <DateVoteAfter vote={vote} onRevote={onRevote} />;
       return <DateVoteComplete vote={vote} />;
     }
 
     if (vote.type === "place") {
       if (vote.status === "before") return <PlaceVoteBefore vote={vote} onVote={onVote} />;
-      if (vote.status === "after") return <PlaceVoteAfter vote={vote} onRevote={onRevote} onComplete={onComplete} />;
+      if (vote.status === "after") return <PlaceVoteAfter vote={vote} onRevote={onRevote} />;
       return <PlaceVoteComplete vote={vote} />;
     }
 
     if (vote.status === "before") return <TextVoteBefore vote={vote} onVote={onVote} />;
-    if (vote.status === "after") return <TextVoteAfter vote={vote} onRevote={onRevote} onComplete={onComplete} />;
+    if (vote.status === "after") return <TextVoteAfter vote={vote} onRevote={onRevote} />;
     return <TextVoteComplete vote={vote} />;
   };
 
@@ -294,55 +318,39 @@ const PostDetailPage: React.FC = () => {
 
   return (
     <div className="min-h-screen w-full bg-[#F2F2F7]">
-      <div className="mx-auto flex w-full max-w-screen-sm flex-col gap-6 px-4 pb-24 pt-8 sm:max-w-screen-md sm:px-6 sm:pb-28 lg:max-w-4xl">
-        <header className="rounded-[24px] bg-white p-6 shadow-sm">
+      <div className="mx-auto flex w-full max-w-screen-sm flex-col gap-5 px-4 pb-24 pt-6">
+        <header className="rounded-[20px] bg-white p-5 shadow-sm">
           <span className="rounded-full bg-[#E1F0FF] px-3 py-1 text-[11px] font-semibold tracking-wide text-[#1E3A8A]">
             게시글 상세
           </span>
-          <h1 className="mt-4 text-left text-2xl font-bold text-[#1C1C1E] sm:text-3xl">{postDetail.title}</h1>
-          <div className="mt-2 flex items-center gap-2 text-xs text-[#8E8E93] sm:text-sm">
+          <h1 className="mt-4 text-left text-xl font-bold text-[#1C1C1E]">{postDetail.title}</h1>
+          <div className="mt-2 flex items-center gap-2 text-xs text-[#8E8E93]">
             <span>{postDetail.authorName}</span>
             <span>•</span>
             <span>{postDetail.createdAt}</span>
           </div>
-          <p className="mt-4 text-sm text-[#1C1C1E] sm:text-base">{postDetail.content}</p>
+          <p className="mt-4 text-sm text-[#1C1C1E]">{postDetail.content}</p>
         </header>
 
         <section className="space-y-4">
-          <div className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className="text-lg font-semibold text-[#1C1C1E]">투표 리스트</h2>
-                <p className="mt-1 text-xs text-[#8E8E93] sm:text-sm">투표 진행 상태에 따라 화면이 변경됩니다.</p>
-              </div>
-              <button
-                onClick={handleAddVote}
-                className="rounded-[16px] bg-[#5856D6] px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
-              >
-                투표 추가
-              </button>
-            </div>
-          </div>
-
           <div className="flex flex-col gap-5">
             {votes.map((vote) => {
-              const typeLabel = vote.type === "date" ? "날짜" : vote.type === "place" ? "장소" : "텍스트";
+              const isClosed = vote.activeYn === "N";
 
               return (
-                <div key={vote.id} className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
+                <div key={vote.id} className="rounded-[20px] bg-white p-5 shadow-sm">
                   <div className="flex items-start justify-between">
                     <div>
-                      <span className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold ${typeBadge[vote.type]}`}>
-                        {typeLabel} 투표
-                      </span>
-                      <h3 className="mt-3 text-lg font-semibold text-[#1C1C1E]">{vote.title}</h3>
+                      <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
                     </div>
-                    <button
-                      onClick={() => handleEndVote(vote.id)}
-                      className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
-                    >
-                      투표 종료
-                    </button>
+                    {!isClosed && (
+                      <button
+                        onClick={() => handleEndVote(vote.id)}
+                        className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
+                      >
+                        투표 종료
+                      </button>
+                    )}
                   </div>
 
                   {renderVoteState(vote)}
@@ -350,15 +358,22 @@ const PostDetailPage: React.FC = () => {
               );
             })}
           </div>
+
+          <button
+            onClick={handleAddVote}
+            className="w-full rounded-[16px] bg-[#5856D6] px-4 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+          >
+            투표 추가
+          </button>
         </section>
 
         <section className="space-y-4">
           <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-[#1C1C1E]">참여여부 투표</h2>
+            <h2 className="text-base font-semibold text-[#1C1C1E]">참여여부 투표</h2>
             {!participationVote && (
               <button
                 onClick={handleCreateParticipationVote}
-                className="rounded-[16px] border border-[#5856D6] px-4 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#4C4ACB] sm:text-sm"
+                className="rounded-[16px] border border-[#5856D6] px-4 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#4C4ACB]"
               >
                 참여여부 투표 생성하기
               </button>
@@ -367,72 +382,90 @@ const PostDetailPage: React.FC = () => {
 
           <div>
             {participationVote ? (
-              <div className="rounded-[24px] bg-white p-5 shadow-sm sm:p-6">
-                <div className="flex items-start justify-between">
+              <div className="rounded-[20px] bg-white p-5 shadow-sm">
+                <div className="flex items-start justify-between gap-4">
                   <div>
-                    <span
-                      className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold ${
-                        participationVote.activeYn === "N" ? "bg-[#FEE2E2] text-[#991B1B]" : "bg-[#E1F0FF] text-[#1E3A8A]"
-                      }`}
-                    >
-                      {participationVote.activeYn === "N" ? "참여여부 투표 종료" : "참여여부 투표"}
-                    </span>
-                    <h3 className="mt-3 text-lg font-semibold text-[#1C1C1E]">참여 가능 여부</h3>
+                    <h3 className="text-base font-semibold text-[#1C1C1E]">참여 가능 여부</h3>
                   </div>
-                  <button
-                    onClick={handleEndParticipationVote}
-                    className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
-                  >
-                    {participationVote.activeYn === "N" ? "종료됨" : "투표 종료"}
-                  </button>
+                  {participationVote.activeYn !== "N" && (
+                    <button
+                      onClick={handleEndParticipationVote}
+                      className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
+                    >
+                      투표 종료
+                    </button>
+                  )}
                 </div>
 
                 {participationVote.activeYn === "N" ? (
-                  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-                    <div className="flex justify-between text-xs text-[#1C1C1E] sm:text-sm">
+                  <div className="mt-3 rounded-[16px] bg-[#F9F9FB] p-4 text-xs text-[#1C1C1E]">
+                    <p className="flex items-center justify-between py-1">
                       <span>참여</span>
-                      <span className="font-semibold">{participationVote.yesCount}명</span>
-                    </div>
-                    <div className="mt-2 flex justify-between text-xs text-[#1C1C1E] sm:text-sm">
+                      <span className="font-semibold text-[#8E8E93]">{participationVote.yesCount}명</span>
+                    </p>
+                    <p className="flex items-center justify-between py-1">
                       <span>불참</span>
-                      <span className="font-semibold">{participationVote.noCount}명</span>
-                    </div>
+                      <span className="font-semibold text-[#8E8E93]">{participationVote.noCount}명</span>
+                    </p>
                   </div>
                 ) : participationVote.hasVoted ? (
-                  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-white p-4">
-                    <p className="text-xs font-semibold text-[#1C1C1E]">투표 후</p>
-                    <div className="mt-3 flex flex-col gap-2 text-xs text-[#1C1C1E] sm:text-sm">
-                      <div className="flex justify-between">
+                  <div className="mt-4 rounded-[16px] border border-[#E5E5EA] bg-white p-4">
+                    <div className="flex flex-col gap-2 text-xs text-[#1C1C1E]">
+                      <div
+                        className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
+                          participationChoice === "yes"
+                            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+                            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+                        }`}
+                      >
                         <span>참여</span>
-                        <span className="font-semibold">{participationVote.yesCount}명</span>
+                        <span className="font-semibold text-[#8E8E93]">{participationVote.yesCount}명</span>
                       </div>
-                      <div className="flex justify-between">
+                      <div
+                        className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
+                          participationChoice === "no"
+                            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+                            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+                        }`}
+                      >
                         <span>불참</span>
-                        <span className="font-semibold">{participationVote.noCount}명</span>
+                        <span className="font-semibold text-[#8E8E93]">{participationVote.noCount}명</span>
                       </div>
                     </div>
                   </div>
                 ) : (
-                  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-                    <p className="text-xs font-semibold text-[#4C4ACB]">투표 전</p>
-                    <div className="mt-3 flex flex-col gap-3">
-                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
-                        <input type="radio" name="participation" className="h-4 w-4 text-[#5856D6]" />
+                  <div className="mt-4 rounded-[16px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+                    <div className="flex flex-col gap-3">
+                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+                        <input
+                          type="radio"
+                          name="participation"
+                          className="h-4 w-4 text-[#5856D6]"
+                          onChange={() => setParticipationChoice("yes")}
+                        />
                         참여
                       </label>
-                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E] sm:text-sm">
-                        <input type="radio" name="participation" className="h-4 w-4 text-[#5856D6]" />
+                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+                        <input
+                          type="radio"
+                          name="participation"
+                          className="h-4 w-4 text-[#5856D6]"
+                          onChange={() => setParticipationChoice("no")}
+                        />
                         불참
                       </label>
                     </div>
-                    <button className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm">
+                    <button
+                      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+                      onClick={handleParticipationVote}
+                    >
                       투표하기
                     </button>
                   </div>
                 )}
               </div>
             ) : (
-              <div className="rounded-[24px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-5 text-xs text-[#8E8E93] sm:text-sm">
+              <div className="rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-5 text-xs text-[#8E8E93]">
                 참여여부 투표를 생성하면 참여 여부를 모을 수 있습니다.
               </div>
             )}
@@ -445,13 +478,13 @@ const PostDetailPage: React.FC = () => {
           <div className="grid grid-cols-2 gap-3">
             <button
               onClick={() => navigate(`/meet/edit/${postDetail.id}`)}
-              className="w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB] sm:text-sm"
+              className="w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
             >
               수정하기
             </button>
             <button
               onClick={() => navigate(`/meet/delete/${postDetail.id}`)}
-              className="w-full rounded-[16px] bg-[#FF3B30] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#e1342b] sm:text-sm"
+              className="w-full rounded-[16px] bg-[#FF3B30] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#e1342b]"
             >
               삭제하기
             </button>

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -3,6 +3,7 @@ export type VoteOption = {
   label: string;
   count: number;
   voted: boolean;
+  memberList?: { name: string }[];
 };
 
 export type VoteType = "date" | "place" | "text";


### PR DESCRIPTION
### Motivation
- Convert the PostDetail voting area to a mobile-first layout and remove desktop-only decorations like type badges.
- Move the `투표 추가` action below the vote list and simplify closed vote display to a compact text summary.
- Expose who voted via popups and mark the option the current user voted for as `내가 투표함`.
- Make before-vote screens allow adding items for `date`/`place`/`text` directly in the list UI.

### Description
- Updated layout and styling in `src/pages/PostDetail.tsx` to be mobile-oriented, removed the `typeBadge` usage, relocated the add-vote button, and simplified closed vote rendering.
- Added `memberList?: { name: string }[]` to `VoteOption` in `src/types/vote.ts` and populated sample data in `fetchVoteList`.
- Reworked vote components in `src/components/vote/DateVote.tsx`, `PlaceVote.tsx`, and `TextVote.tsx` to: (1) add input UI for new items in the "before" state, (2) remove the after-state submission button, (3) show a compact after-state with a count button that opens `VotedMemberList` popup, and (4) show a `내가 투표함` badge on voted options.
- Refactored the participation vote flow in `PostDetail.tsx` by introducing `participationChoice` and `handleParticipationVote` and unifying before/after display logic.

### Testing
- Started the dev server with `npm run dev` and verified the app served at the development URL successfully.
- Captured a mobile viewport screenshot using Playwright and saved it as `artifacts/post-detail-mobile.png`, which rendered the updated `PostDetail` page correctly.
- No unit or integration test suites were executed as part of this change (UI-only updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949575f25388324990c3bd2fe5b9037)