### PR TITLE
PostDetail: multi-select voting, option add flows, vote creation modal and deadlines

### DIFF
--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -7,7 +7,7 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
     {options.map((option) => (
       <div
         key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
+        className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
           highlightVoted && option.voted
             ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
@@ -29,6 +29,7 @@ export const DateVoteBefore: React.FC<{
   onAddOption: (label: string) => void;
 }> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
   const [isAdding, setIsAdding] = useState(false);
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [newOption, setNewOption] = useState("");
 
   const handleAdd = () => {
@@ -43,7 +44,7 @@ export const DateVoteBefore: React.FC<{
     <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
       <div className="mt-3 flex flex-col gap-3">
         {vote.options.map((option) => (
-          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-2 text-xs text-[#1C1C1E]">
             <input
               type={allowDuplicate ? "checkbox" : "radio"}
               name={allowDuplicate ? undefined : `date-vote-${vote.id}`}
@@ -60,19 +61,19 @@ export const DateVoteBefore: React.FC<{
         <button
           type="button"
           onClick={() => setIsAdding(true)}
-          className="w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+          className="w-full rounded-[12px] bg-[#EAE9FF] px-3 py-2 text-xs font-semibold text-[#5856D6]"
         >
           항목 추가하기
         </button>
       ) : (
         <div className="space-y-2">
-          <input
-            type="datetime-local"
-            value={newOption}
-            onChange={(event) => setNewOption(event.target.value)}
-            inputMode="numeric"
-            className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
-          />
+          <button
+            type="button"
+            onClick={() => setIsPopupOpen(true)}
+            className="w-full rounded-[12px] bg-[#EAE9FF] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+          >
+            {newOption ? newOption.replace("T", " ") : "날짜와 시간 선택"}
+          </button>
           <div className="flex gap-2">
             <button
               type="button"
@@ -95,15 +96,45 @@ export const DateVoteBefore: React.FC<{
         </div>
       )}
     </div>
-      <button
+    <button
         type="button"
         onClick={onVote}
         className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
       >
-        투표하기
-      </button>
-    </div>
-  );
+      투표하기
+    </button>
+    {isPopupOpen && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#5856D6]/20 px-4">
+        <div className="w-full max-w-sm rounded-[20px] bg-white p-5 shadow-lg">
+          <h4 className="text-sm font-semibold text-[#1C1C1E]">날짜와 시간 선택</h4>
+          <input
+            type="datetime-local"
+            value={newOption}
+            onChange={(event) => setNewOption(event.target.value)}
+            inputMode="numeric"
+            className="mt-3 w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+          />
+          <div className="mt-4 flex gap-2">
+            <button
+              type="button"
+              onClick={() => setIsPopupOpen(false)}
+              className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6]"
+            >
+              닫기
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsPopupOpen(false)}
+              className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+            >
+              확인
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
+  </div>
+);
 };
 
 export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ vote, onRevote }) => {
@@ -116,9 +147,9 @@ export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
         {vote.options.map((option) => (
           <div
             key={option.id}
-            className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
-              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-            }`}
+          className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
+            option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+          }`}
           >
             <span>{option.label}</span>
             <button

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -28,16 +28,18 @@ export const DateVoteBefore: React.FC<{
   onVote: () => void;
   onAddOption: (label: string) => void;
 }> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
-  const [isAdding, setIsAdding] = useState(false);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [newOption, setNewOption] = useState("");
+  const [dateInput, setDateInput] = useState("");
+  const [hourInput, setHourInput] = useState("");
+  const [minuteInput, setMinuteInput] = useState("");
 
-  const handleAdd = () => {
-    if (!newOption) return;
-    const formatted = newOption.replace("T", " ");
-    onAddOption(formatted);
-    setNewOption("");
-    setIsAdding(false);
+  const handleConfirm = () => {
+    if (!dateInput || !hourInput || !minuteInput) return;
+    onAddOption(`${dateInput} ${hourInput}:${minuteInput}`);
+    setDateInput("");
+    setHourInput("");
+    setMinuteInput("");
+    setIsPopupOpen(false);
   };
 
   return (
@@ -56,45 +58,14 @@ export const DateVoteBefore: React.FC<{
           </label>
         ))}
       </div>
-    <div className="mt-4 space-y-2">
-      {!isAdding ? (
-        <button
-          type="button"
-          onClick={() => setIsAdding(true)}
-          className="w-full rounded-[12px] bg-[#EAE9FF] px-3 py-2 text-xs font-semibold text-[#5856D6]"
-        >
-          항목 추가하기
-        </button>
-      ) : (
-        <div className="space-y-2">
-          <button
-            type="button"
-            onClick={() => setIsPopupOpen(true)}
-            className="w-full rounded-[12px] bg-[#EAE9FF] px-3 py-2 text-xs font-semibold text-[#5856D6]"
-          >
-            {newOption ? newOption.replace("T", " ") : "날짜와 시간 선택"}
-          </button>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={handleAdd}
-              className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-            >
-              추가하기
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setIsAdding(false);
-                setNewOption("");
-              }}
-              className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
-            >
-              취소
-            </button>
-          </div>
-        </div>
-      )}
+    <div className="mt-4">
+      <button
+        type="button"
+        onClick={() => setIsPopupOpen(true)}
+        className="w-full rounded-[12px] bg-[#EAE9FF] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+      >
+        항목 추가하기
+      </button>
     </div>
     <button
         type="button"
@@ -106,25 +77,52 @@ export const DateVoteBefore: React.FC<{
     {isPopupOpen && (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#5856D6]/20 px-4">
         <div className="w-full max-w-sm rounded-[20px] bg-white p-5 shadow-lg">
-          <h4 className="text-sm font-semibold text-[#1C1C1E]">날짜와 시간 선택</h4>
-          <input
-            type="datetime-local"
-            value={newOption}
-            onChange={(event) => setNewOption(event.target.value)}
-            inputMode="numeric"
-            className="mt-3 w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
-          />
-          <div className="mt-4 flex gap-2">
+          <h4 className="text-sm font-semibold text-[#1C1C1E]">날짜와 시간 입력</h4>
+          <div className="mt-4 space-y-3">
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-semibold text-[#8E8E93]">날짜</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                placeholder="YYYY.MM.DD"
+                value={dateInput}
+                onChange={(event) => setDateInput(event.target.value)}
+                className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-semibold text-[#8E8E93]">시간</span>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="HH"
+                  value={hourInput}
+                  onChange={(event) => setHourInput(event.target.value)}
+                  className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+                />
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="MM"
+                  value={minuteInput}
+                  onChange={(event) => setMinuteInput(event.target.value)}
+                  className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+                />
+              </div>
+            </div>
+          </div>
+          <div className="mt-5 flex gap-2">
             <button
               type="button"
               onClick={() => setIsPopupOpen(false)}
               className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6]"
             >
-              닫기
+              취소
             </button>
             <button
               type="button"
-              onClick={() => setIsPopupOpen(false)}
+              onClick={handleConfirm}
               className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
             >
               확인
@@ -154,7 +152,7 @@ export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
             <span>{option.label}</span>
             <button
               type="button"
-              className="text-[11px] font-semibold text-[#5856D6]"
+              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
               onClick={() => setSelectedOptionId(option.id)}
             >
               {option.count}명

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -29,18 +29,32 @@ export const DateVoteBefore: React.FC<{
   onAddOption: (label: string) => void;
 }> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [dateInput, setDateInput] = useState("");
-  const [hourInput, setHourInput] = useState("");
-  const [minuteInput, setMinuteInput] = useState("");
+  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedPeriod, setSelectedPeriod] = useState<"오전" | "오후">("오전");
+  const [selectedHour, setSelectedHour] = useState("");
+  const [selectedMinute, setSelectedMinute] = useState("");
 
   const handleConfirm = () => {
-    if (!dateInput || !hourInput || !minuteInput) return;
-    onAddOption(`${dateInput} ${hourInput}:${minuteInput}`);
-    setDateInput("");
-    setHourInput("");
-    setMinuteInput("");
+    if (!selectedDate || !selectedHour || !selectedMinute) return;
+    onAddOption(`${selectedDate} ${selectedPeriod} ${selectedHour}:${selectedMinute}`);
+    setSelectedDate("");
+    setSelectedPeriod("오전");
+    setSelectedHour("");
+    setSelectedMinute("");
     setIsPopupOpen(false);
   };
+
+  const today = new Date();
+  const dateOptions = Array.from({ length: 5 }, (_, index) => {
+    const date = new Date(today);
+    date.setDate(today.getDate() + index);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}.${month}.${day}`;
+  });
+  const hourOptions = Array.from({ length: 12 }, (_, index) => String(index + 1).padStart(2, "0"));
+  const minuteOptions = ["00", "30"];
 
   return (
     <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
@@ -77,38 +91,71 @@ export const DateVoteBefore: React.FC<{
     {isPopupOpen && (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#5856D6]/20 px-4">
         <div className="w-full max-w-sm rounded-[20px] bg-white p-5 shadow-lg">
-          <h4 className="text-sm font-semibold text-[#1C1C1E]">날짜와 시간 입력</h4>
-          <div className="mt-4 space-y-3">
-            <div className="flex flex-col gap-2">
-              <span className="text-[11px] font-semibold text-[#8E8E93]">날짜</span>
-              <input
-                type="text"
-                inputMode="numeric"
-                placeholder="YYYY.MM.DD"
-                value={dateInput}
-                onChange={(event) => setDateInput(event.target.value)}
-                className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
-              />
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              {dateOptions.map((date) => (
+                <button
+                  key={date}
+                  type="button"
+                  onClick={() => setSelectedDate(date)}
+                  className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                    selectedDate === date
+                      ? "bg-[#5856D6] text-white"
+                      : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                  }`}
+                >
+                  {date}
+                </button>
+              ))}
             </div>
             <div className="flex flex-col gap-2">
-              <span className="text-[11px] font-semibold text-[#8E8E93]">시간</span>
               <div className="flex gap-2">
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  placeholder="HH"
-                  value={hourInput}
-                  onChange={(event) => setHourInput(event.target.value)}
-                  className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
-                />
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  placeholder="MM"
-                  value={minuteInput}
-                  onChange={(event) => setMinuteInput(event.target.value)}
-                  className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
-                />
+                {(["오전", "오후"] as const).map((period) => (
+                  <button
+                    key={period}
+                    type="button"
+                    onClick={() => setSelectedPeriod(period)}
+                    className={`flex-1 rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                      selectedPeriod === period
+                        ? "bg-[#5856D6] text-white"
+                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                    }`}
+                  >
+                    {period}
+                  </button>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {hourOptions.map((hour) => (
+                  <button
+                    key={hour}
+                    type="button"
+                    onClick={() => setSelectedHour(hour)}
+                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                      selectedHour === hour
+                        ? "bg-[#5856D6] text-white"
+                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                    }`}
+                  >
+                    {hour}
+                  </button>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                {minuteOptions.map((minute) => (
+                  <button
+                    key={minute}
+                    type="button"
+                    onClick={() => setSelectedMinute(minute)}
+                    className={`flex-1 rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                      selectedMinute === minute
+                        ? "bg-[#5856D6] text-white"
+                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                    }`}
+                  >
+                    {minute}
+                  </button>
+                ))}
               </div>
             </div>
           </div>

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -29,15 +29,21 @@ export const DateVoteBefore: React.FC<{
   onAddOption: (label: string) => void;
 }> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [selectedDate, setSelectedDate] = useState("");
+  const [selectedYear, setSelectedYear] = useState("");
+  const [selectedMonth, setSelectedMonth] = useState("");
+  const [selectedDay, setSelectedDay] = useState("");
   const [selectedPeriod, setSelectedPeriod] = useState<"오전" | "오후">("오전");
   const [selectedHour, setSelectedHour] = useState("");
   const [selectedMinute, setSelectedMinute] = useState("");
 
   const handleConfirm = () => {
-    if (!selectedDate || !selectedHour || !selectedMinute) return;
-    onAddOption(`${selectedDate} ${selectedPeriod} ${selectedHour}:${selectedMinute}`);
-    setSelectedDate("");
+    if (!selectedYear || !selectedMonth || !selectedDay || !selectedHour || !selectedMinute) return;
+    const month = selectedMonth.padStart(2, "0");
+    const day = selectedDay.padStart(2, "0");
+    onAddOption(`${selectedYear}.${month}.${day} ${selectedPeriod} ${selectedHour}:${selectedMinute}`);
+    setSelectedYear("");
+    setSelectedMonth("");
+    setSelectedDay("");
     setSelectedPeriod("오전");
     setSelectedHour("");
     setSelectedMinute("");
@@ -45,14 +51,9 @@ export const DateVoteBefore: React.FC<{
   };
 
   const today = new Date();
-  const dateOptions = Array.from({ length: 5 }, (_, index) => {
-    const date = new Date(today);
-    date.setDate(today.getDate() + index);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}.${month}.${day}`;
-  });
+  const yearOptions = [String(today.getFullYear()), String(today.getFullYear() + 1)];
+  const monthOptions = Array.from({ length: 12 }, (_, index) => String(index + 1));
+  const dayOptions = Array.from({ length: 31 }, (_, index) => String(index + 1));
   const hourOptions = Array.from({ length: 12 }, (_, index) => String(index + 1).padStart(2, "0"));
   const minuteOptions = ["00", "30"];
 
@@ -92,30 +93,62 @@ export const DateVoteBefore: React.FC<{
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#5856D6]/20 px-4">
         <div className="w-full max-w-sm rounded-[20px] bg-white p-5 shadow-lg">
           <div className="space-y-4">
-            <div className="flex flex-wrap gap-2">
-              {dateOptions.map((date) => (
-                <button
-                  key={date}
-                  type="button"
-                  onClick={() => setSelectedDate(date)}
-                  className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                    selectedDate === date
-                      ? "bg-[#5856D6] text-white"
-                      : "border border-[#E5E5EA] bg-white text-[#5856D6]"
-                  }`}
-                >
-                  {date}
-                </button>
-              ))}
+            <div className="space-y-2">
+              <span className="text-[11px] font-semibold text-[#8E8E93]">날짜</span>
+              <div className="flex gap-2 overflow-x-auto">
+                {yearOptions.map((year) => (
+                  <button
+                    key={year}
+                    type="button"
+                    onClick={() => setSelectedYear(year)}
+                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                      selectedYear === year ? "bg-[#5856D6] text-white" : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                    }`}
+                  >
+                    {year}년
+                  </button>
+                ))}
+              </div>
+              <div className="flex gap-2 overflow-x-auto">
+                {monthOptions.map((month) => (
+                  <button
+                    key={month}
+                    type="button"
+                    onClick={() => setSelectedMonth(month)}
+                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                      selectedMonth === month
+                        ? "bg-[#5856D6] text-white"
+                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                    }`}
+                  >
+                    {month}월
+                  </button>
+                ))}
+              </div>
+              <div className="flex gap-2 overflow-x-auto">
+                {dayOptions.map((day) => (
+                  <button
+                    key={day}
+                    type="button"
+                    onClick={() => setSelectedDay(day)}
+                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                      selectedDay === day ? "bg-[#5856D6] text-white" : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                    }`}
+                  >
+                    {day}일
+                  </button>
+                ))}
+              </div>
             </div>
-            <div className="flex flex-col gap-2">
-              <div className="flex gap-2">
+            <div className="space-y-2">
+              <span className="text-[11px] font-semibold text-[#8E8E93]">시간</span>
+              <div className="flex gap-2 overflow-x-auto">
                 {(["오전", "오후"] as const).map((period) => (
                   <button
                     key={period}
                     type="button"
                     onClick={() => setSelectedPeriod(period)}
-                    className={`flex-1 rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
                       selectedPeriod === period
                         ? "bg-[#5856D6] text-white"
                         : "border border-[#E5E5EA] bg-white text-[#5856D6]"
@@ -125,35 +158,33 @@ export const DateVoteBefore: React.FC<{
                   </button>
                 ))}
               </div>
-              <div className="flex flex-wrap gap-2">
+              <div className="flex gap-2 overflow-x-auto">
                 {hourOptions.map((hour) => (
                   <button
                     key={hour}
                     type="button"
                     onClick={() => setSelectedHour(hour)}
                     className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                      selectedHour === hour
-                        ? "bg-[#5856D6] text-white"
-                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
+                      selectedHour === hour ? "bg-[#5856D6] text-white" : "border border-[#E5E5EA] bg-white text-[#5856D6]"
                     }`}
                   >
-                    {hour}
+                    {hour}시
                   </button>
                 ))}
               </div>
-              <div className="flex gap-2">
+              <div className="flex gap-2 overflow-x-auto">
                 {minuteOptions.map((minute) => (
                   <button
                     key={minute}
                     type="button"
                     onClick={() => setSelectedMinute(minute)}
-                    className={`flex-1 rounded-[10px] px-3 py-2 text-xs font-semibold ${
+                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
                       selectedMinute === minute
                         ? "bg-[#5856D6] text-white"
                         : "border border-[#E5E5EA] bg-white text-[#5856D6]"
                     }`}
                   >
-                    {minute}
+                    {minute}분
                   </button>
                 ))}
               </div>

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -13,14 +13,7 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
         }`}
       >
-        <div className="flex items-center gap-2">
-          <span>{option.label}</span>
-          {highlightVoted && option.voted && (
-            <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
-              내가 투표함
-            </span>
-          )}
-        </div>
+        <span>{option.label}</span>
         <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
       </div>
     ))}
@@ -29,11 +22,12 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
 
 export const DateVoteBefore: React.FC<{
   vote: Vote;
+  allowDuplicate: boolean;
   selectedOptionIds: string[];
   onToggleOption: (optionId: string) => void;
   onVote: () => void;
   onAddOption: (label: string) => void;
-}> = ({ vote, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+}> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
   const [isAdding, setIsAdding] = useState(false);
   const [newOption, setNewOption] = useState("");
 
@@ -51,7 +45,8 @@ export const DateVoteBefore: React.FC<{
         {vote.options.map((option) => (
           <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
             <input
-              type="checkbox"
+              type={allowDuplicate ? "checkbox" : "radio"}
+              name={allowDuplicate ? undefined : `date-vote-${vote.id}`}
               checked={selectedOptionIds.includes(option.id)}
               onChange={() => onToggleOption(option.id)}
               className="h-4 w-4 text-[#5856D6]"
@@ -61,7 +56,6 @@ export const DateVoteBefore: React.FC<{
         ))}
       </div>
     <div className="mt-4 space-y-2">
-      <label className="text-[11px] font-semibold text-[#8E8E93]">날짜 추가</label>
       {!isAdding ? (
         <button
           type="button"
@@ -76,7 +70,8 @@ export const DateVoteBefore: React.FC<{
             type="datetime-local"
             value={newOption}
             onChange={(event) => setNewOption(event.target.value)}
-            className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-xs font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+            inputMode="numeric"
+            className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-sm font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
           />
           <div className="flex gap-2">
             <button
@@ -125,14 +120,7 @@ export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
               option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
             }`}
           >
-            <div className="flex items-center gap-2">
-              <span>{option.label}</span>
-              {option.voted && (
-                <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
-                  내가 투표함
-                </span>
-              )}
-            </div>
+            <span>{option.label}</span>
             <button
               type="button"
               className="text-[11px] font-semibold text-[#5856D6]"

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -56,6 +56,20 @@ export const DateVoteBefore: React.FC<{
   const dayOptions = Array.from({ length: 31 }, (_, index) => String(index + 1));
   const hourOptions = Array.from({ length: 12 }, (_, index) => String(index + 1).padStart(2, "0"));
   const minuteOptions = ["00", "30"];
+  const renderPickerColumn = <T extends string>(items: T[], selected: T, onSelect: (value: T) => void) => (
+    <div className="h-36 w-16 overflow-y-auto rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] py-2 text-center text-xs font-semibold text-[#5856D6]">
+      {items.map((item) => (
+        <button
+          key={item}
+          type="button"
+          onClick={() => onSelect(item)}
+          className={`block w-full py-2 ${selected === item ? "bg-[#EAE9FF] text-[#5856D6]" : "text-[#8E8E93]"}`}
+        >
+          {item}
+        </button>
+      ))}
+    </div>
+  );
 
   return (
     <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
@@ -95,98 +109,18 @@ export const DateVoteBefore: React.FC<{
           <div className="space-y-4">
             <div className="space-y-2">
               <span className="text-[11px] font-semibold text-[#8E8E93]">날짜</span>
-              <div className="flex gap-2 overflow-x-auto">
-                {yearOptions.map((year) => (
-                  <button
-                    key={year}
-                    type="button"
-                    onClick={() => setSelectedYear(year)}
-                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                      selectedYear === year ? "bg-[#5856D6] text-white" : "border border-[#E5E5EA] bg-white text-[#5856D6]"
-                    }`}
-                  >
-                    {year}년
-                  </button>
-                ))}
-              </div>
-              <div className="flex gap-2 overflow-x-auto">
-                {monthOptions.map((month) => (
-                  <button
-                    key={month}
-                    type="button"
-                    onClick={() => setSelectedMonth(month)}
-                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                      selectedMonth === month
-                        ? "bg-[#5856D6] text-white"
-                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
-                    }`}
-                  >
-                    {month}월
-                  </button>
-                ))}
-              </div>
-              <div className="flex gap-2 overflow-x-auto">
-                {dayOptions.map((day) => (
-                  <button
-                    key={day}
-                    type="button"
-                    onClick={() => setSelectedDay(day)}
-                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                      selectedDay === day ? "bg-[#5856D6] text-white" : "border border-[#E5E5EA] bg-white text-[#5856D6]"
-                    }`}
-                  >
-                    {day}일
-                  </button>
-                ))}
+              <div className="flex gap-2">
+                {renderPickerColumn(yearOptions, selectedYear, setSelectedYear)}
+                {renderPickerColumn(monthOptions, selectedMonth, setSelectedMonth)}
+                {renderPickerColumn(dayOptions, selectedDay, setSelectedDay)}
               </div>
             </div>
             <div className="space-y-2">
               <span className="text-[11px] font-semibold text-[#8E8E93]">시간</span>
-              <div className="flex gap-2 overflow-x-auto">
-                {(["오전", "오후"] as const).map((period) => (
-                  <button
-                    key={period}
-                    type="button"
-                    onClick={() => setSelectedPeriod(period)}
-                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                      selectedPeriod === period
-                        ? "bg-[#5856D6] text-white"
-                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
-                    }`}
-                  >
-                    {period}
-                  </button>
-                ))}
-              </div>
-              <div className="flex gap-2 overflow-x-auto">
-                {hourOptions.map((hour) => (
-                  <button
-                    key={hour}
-                    type="button"
-                    onClick={() => setSelectedHour(hour)}
-                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                      selectedHour === hour ? "bg-[#5856D6] text-white" : "border border-[#E5E5EA] bg-white text-[#5856D6]"
-                    }`}
-                  >
-                    {hour}시
-                  </button>
-                ))}
-              </div>
-              <div className="flex gap-2 overflow-x-auto">
-                {minuteOptions.map((minute) => (
-                  <button
-                    key={minute}
-                    type="button"
-                    onClick={() => setSelectedMinute(minute)}
-                    className={`rounded-[10px] px-3 py-2 text-xs font-semibold ${
-                      selectedMinute === minute
-                        ? "bg-[#5856D6] text-white"
-                        : "border border-[#E5E5EA] bg-white text-[#5856D6]"
-                    }`}
-                  >
-                    {minute}분
-                  </button>
-                ))}
+              <div className="flex gap-2">
+                {renderPickerColumn(["오전", "오후"] as const, selectedPeriod, setSelectedPeriod)}
+                {renderPickerColumn(hourOptions, selectedHour, setSelectedHour)}
+                {renderPickerColumn(minuteOptions, selectedMinute, setSelectedMinute)}
               </div>
             </div>
           </div>

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -27,38 +27,89 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
   </div>
 );
 
-export const DateVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
-  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-    <div className="mt-3 flex flex-col gap-3">
-      {vote.options.map((option) => (
-        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
-          <input type="radio" name={`date-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
-          {option.label}
-        </label>
-      ))}
-    </div>
-    <div className="mt-4 rounded-xl bg-white px-4 py-3">
-      <label className="text-[11px] font-semibold text-[#8E8E93]">날짜 추가</label>
-      <input
-        type="date"
-        className="mt-2 w-full rounded-lg border border-[#E5E5EA] px-3 py-2 text-xs text-[#1C1C1E]"
-      />
+export const DateVoteBefore: React.FC<{
+  vote: Vote;
+  selectedOptionIds: string[];
+  onToggleOption: (optionId: string) => void;
+  onVote: () => void;
+  onAddOption: (label: string) => void;
+}> = ({ vote, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+  const [isAdding, setIsAdding] = useState(false);
+  const [newOption, setNewOption] = useState("");
+
+  const handleAdd = () => {
+    if (!newOption) return;
+    const formatted = newOption.replace("T", " ");
+    onAddOption(formatted);
+    setNewOption("");
+    setIsAdding(false);
+  };
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+      <div className="mt-3 flex flex-col gap-3">
+        {vote.options.map((option) => (
+          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+            <input
+              type="checkbox"
+              checked={selectedOptionIds.includes(option.id)}
+              onChange={() => onToggleOption(option.id)}
+              className="h-4 w-4 text-[#5856D6]"
+            />
+            {option.label}
+          </label>
+        ))}
+      </div>
+      <div className="mt-4 rounded-xl bg-white px-4 py-3">
+        <label className="text-[11px] font-semibold text-[#8E8E93]">날짜 추가</label>
+        {!isAdding ? (
+          <button
+            type="button"
+            onClick={() => setIsAdding(true)}
+            className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+          >
+            항목 추가하기
+          </button>
+        ) : (
+          <div className="mt-2 space-y-2">
+            <input
+              type="datetime-local"
+              value={newOption}
+              onChange={(event) => setNewOption(event.target.value)}
+              className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-xs font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleAdd}
+                className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+              >
+                추가하기
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setIsAdding(false);
+                  setNewOption("");
+                }}
+                className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
       <button
         type="button"
-        className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+        onClick={onVote}
+        className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
       >
-        항목 추가하기
+        투표하기
       </button>
     </div>
-    <button
-      type="button"
-      onClick={onVote}
-      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-    >
-      투표하기
-    </button>
-  </div>
-);
+  );
+};
 
 export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ vote, onRevote }) => {
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -60,46 +60,46 @@ export const DateVoteBefore: React.FC<{
           </label>
         ))}
       </div>
-      <div className="mt-4 rounded-xl bg-white px-4 py-3">
-        <label className="text-[11px] font-semibold text-[#8E8E93]">날짜 추가</label>
-        {!isAdding ? (
-          <button
-            type="button"
-            onClick={() => setIsAdding(true)}
-            className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
-          >
-            항목 추가하기
-          </button>
-        ) : (
-          <div className="mt-2 space-y-2">
-            <input
-              type="datetime-local"
-              value={newOption}
-              onChange={(event) => setNewOption(event.target.value)}
-              className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-xs font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
-            />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={handleAdd}
-                className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-              >
-                추가하기
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setIsAdding(false);
-                  setNewOption("");
-                }}
-                className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
-              >
-                취소
-              </button>
-            </div>
+    <div className="mt-4 space-y-2">
+      <label className="text-[11px] font-semibold text-[#8E8E93]">날짜 추가</label>
+      {!isAdding ? (
+        <button
+          type="button"
+          onClick={() => setIsAdding(true)}
+          className="w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+        >
+          항목 추가하기
+        </button>
+      ) : (
+        <div className="space-y-2">
+          <input
+            type="datetime-local"
+            value={newOption}
+            onChange={(event) => setNewOption(event.target.value)}
+            className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-xs font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+            >
+              추가하기
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsAdding(false);
+                setNewOption("");
+              }}
+              className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+            >
+              취소
+            </button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
+    </div>
       <button
         type="button"
         onClick={onVote}

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -66,47 +66,47 @@ export const PlaceVoteBefore: React.FC<{
           </label>
         ))}
       </div>
-      <div className="mt-4 rounded-xl bg-white px-4 py-3">
-        <label className="text-[11px] font-semibold text-[#8E8E93]">장소 추가</label>
-        {!isAdding ? (
+    <div className="mt-4 space-y-2">
+      <label className="text-[11px] font-semibold text-[#8E8E93]">장소 추가</label>
+      {!isAdding ? (
+        <button
+          type="button"
+          onClick={() => setIsAdding(true)}
+          className="w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+        >
+          항목 추가하기
+        </button>
+      ) : (
+        <div className="space-y-2">
           <button
             type="button"
-            onClick={() => setIsAdding(true)}
-            className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+            className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-left text-xs font-semibold text-[#5856D6] focus:border-[#FFE607]"
+            onClick={() => setIsPopupOpen(true)}
           >
-            항목 추가하기
+            {selectedPlace || "장소를 선택하세요"}
           </button>
-        ) : (
-          <div className="mt-2 space-y-2">
+          <div className="flex gap-2">
             <button
               type="button"
-              className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-left text-xs font-semibold text-[#5856D6] focus:border-[#FFE607]"
-              onClick={() => setIsPopupOpen(true)}
+              onClick={handleAdd}
+              className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
             >
-              {selectedPlace || "장소를 선택하세요"}
+              추가하기
             </button>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={handleAdd}
-                className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-              >
-                추가하기
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setIsAdding(false);
-                  setSelectedPlace("");
-                }}
-                className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
-              >
-                취소
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setIsAdding(false);
+                setSelectedPlace("");
+              }}
+              className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+            >
+              취소
+            </button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
+    </div>
       <button
         type="button"
         onClick={onVote}

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -130,7 +130,7 @@ export const PlaceVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({
             <span>{option.label}</span>
             <button
               type="button"
-              className="text-[11px] font-semibold text-[#5856D6]"
+              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
               onClick={() => setSelectedOptionId(option.id)}
             >
               {option.count}명

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -28,13 +28,27 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
   </div>
 );
 
-export const PlaceVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => {
+export const PlaceVoteBefore: React.FC<{
+  vote: Vote;
+  selectedOptionIds: string[];
+  onToggleOption: (optionId: string) => void;
+  onVote: () => void;
+  onAddOption: (label: string) => void;
+}> = ({ vote, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<string>("");
+  const [isAdding, setIsAdding] = useState(false);
 
   const handlePopupSelect = (location: { x: string; y: string; address: string }) => {
     setSelectedPlace(location.address);
     setIsPopupOpen(false);
+  };
+
+  const handleAdd = () => {
+    if (!selectedPlace) return;
+    onAddOption(selectedPlace);
+    setSelectedPlace("");
+    setIsAdding(false);
   };
 
   return (
@@ -42,26 +56,56 @@ export const PlaceVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ 
       <div className="mt-3 flex flex-col gap-3">
         {vote.options.map((option) => (
           <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
-            <input type="radio" name={`place-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
+            <input
+              type="checkbox"
+              checked={selectedOptionIds.includes(option.id)}
+              onChange={() => onToggleOption(option.id)}
+              className="h-4 w-4 text-[#5856D6]"
+            />
             {option.label}
           </label>
         ))}
       </div>
       <div className="mt-4 rounded-xl bg-white px-4 py-3">
         <label className="text-[11px] font-semibold text-[#8E8E93]">장소 추가</label>
-        <button
-          type="button"
-          className="mt-2 w-full rounded-lg border border-[#E5E5EA] px-3 py-2 text-left text-xs text-[#5856D6]"
-          onClick={() => setIsPopupOpen(true)}
-        >
-          {selectedPlace || "장소를 선택하세요"}
-        </button>
-        <button
-          type="button"
-          className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
-        >
-          항목 추가하기
-        </button>
+        {!isAdding ? (
+          <button
+            type="button"
+            onClick={() => setIsAdding(true)}
+            className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+          >
+            항목 추가하기
+          </button>
+        ) : (
+          <div className="mt-2 space-y-2">
+            <button
+              type="button"
+              className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-left text-xs font-semibold text-[#5856D6] focus:border-[#FFE607]"
+              onClick={() => setIsPopupOpen(true)}
+            >
+              {selectedPlace || "장소를 선택하세요"}
+            </button>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleAdd}
+                className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+              >
+                추가하기
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setIsAdding(false);
+                  setSelectedPlace("");
+                }}
+                className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        )}
       </div>
       <button
         type="button"

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -34,6 +34,13 @@ export const PlaceVoteBefore: React.FC<{
   const [isAdding, setIsAdding] = useState(false);
 
   const handlePopupSelect = (location: { x: string; y: string; address: string }) => {
+    if (isAdding) {
+      onAddOption(location.address);
+      setSelectedPlace("");
+      setIsAdding(false);
+      setIsPopupOpen(false);
+      return;
+    }
     setSelectedPlace(location.address);
     setIsPopupOpen(false);
   };

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -8,7 +8,7 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
     {options.map((option) => (
       <div
         key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
+        className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
           highlightVoted && option.voted
             ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
@@ -49,7 +49,7 @@ export const PlaceVoteBefore: React.FC<{
     <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
       <div className="mt-3 flex flex-col gap-3">
         {vote.options.map((option) => (
-          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-2 text-xs text-[#1C1C1E]">
             <input
               type={allowDuplicate ? "checkbox" : "radio"}
               name={allowDuplicate ? undefined : `place-vote-${vote.id}`}
@@ -66,7 +66,7 @@ export const PlaceVoteBefore: React.FC<{
         <button
           type="button"
           onClick={() => setIsAdding(true)}
-          className="w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+          className="w-full rounded-[12px] bg-[#EAE9FF] px-3 py-2 text-xs font-semibold text-[#5856D6]"
         >
           항목 추가하기
         </button>
@@ -123,9 +123,9 @@ export const PlaceVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({
         {vote.options.map((option) => (
           <div
             key={option.id}
-            className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
-              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-            }`}
+          className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
+            option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+          }`}
           >
             <span>{option.label}</span>
             <button

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -14,14 +14,7 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
         }`}
       >
-        <div className="flex items-center gap-2">
-          <span>{option.label}</span>
-          {highlightVoted && option.voted && (
-            <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
-              내가 투표함
-            </span>
-          )}
-        </div>
+        <span>{option.label}</span>
         <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
       </div>
     ))}
@@ -30,11 +23,12 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
 
 export const PlaceVoteBefore: React.FC<{
   vote: Vote;
+  allowDuplicate: boolean;
   selectedOptionIds: string[];
   onToggleOption: (optionId: string) => void;
   onVote: () => void;
   onAddOption: (label: string) => void;
-}> = ({ vote, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+}> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<string>("");
   const [isAdding, setIsAdding] = useState(false);
@@ -57,7 +51,8 @@ export const PlaceVoteBefore: React.FC<{
         {vote.options.map((option) => (
           <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
             <input
-              type="checkbox"
+              type={allowDuplicate ? "checkbox" : "radio"}
+              name={allowDuplicate ? undefined : `place-vote-${vote.id}`}
               checked={selectedOptionIds.includes(option.id)}
               onChange={() => onToggleOption(option.id)}
               className="h-4 w-4 text-[#5856D6]"
@@ -67,7 +62,6 @@ export const PlaceVoteBefore: React.FC<{
         ))}
       </div>
     <div className="mt-4 space-y-2">
-      <label className="text-[11px] font-semibold text-[#8E8E93]">장소 추가</label>
       {!isAdding ? (
         <button
           type="button"
@@ -133,14 +127,7 @@ export const PlaceVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({
               option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
             }`}
           >
-            <div className="flex items-center gap-2">
-              <span>{option.label}</span>
-              {option.voted && (
-                <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
-                  내가 투표함
-                </span>
-              )}
-            </div>
+            <span>{option.label}</span>
             <button
               type="button"
               className="text-[11px] font-semibold text-[#5856D6]"

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -59,47 +59,47 @@ export const TextVoteBefore: React.FC<{
           </label>
         ))}
       </div>
-      <div className="mt-4 rounded-xl bg-white px-4 py-3">
-        <label className="text-[11px] font-semibold text-[#8E8E93]">텍스트 추가</label>
-        {!isAdding ? (
-          <button
-            type="button"
-            onClick={() => setIsAdding(true)}
-            className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
-          >
-            항목 추가하기
-          </button>
-        ) : (
-          <div className="mt-2 space-y-2">
-            <input
-              type="text"
-              value={newOption}
-              onChange={(event) => setNewOption(event.target.value)}
-              placeholder="텍스트 입력"
-              className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-xs font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
-            />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={handleAdd}
-                className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-              >
-                추가하기
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setIsAdding(false);
-                  setNewOption("");
-                }}
-                className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
-              >
-                취소
-              </button>
-            </div>
+    <div className="mt-4 space-y-2">
+      <label className="text-[11px] font-semibold text-[#8E8E93]">텍스트 추가</label>
+      {!isAdding ? (
+        <button
+          type="button"
+          onClick={() => setIsAdding(true)}
+          className="w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+        >
+          항목 추가하기
+        </button>
+      ) : (
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={newOption}
+            onChange={(event) => setNewOption(event.target.value)}
+            placeholder="텍스트 입력"
+            className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-xs font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+            >
+              추가하기
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsAdding(false);
+                setNewOption("");
+              }}
+              className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+            >
+              취소
+            </button>
           </div>
-        )}
-      </div>
+        </div>
+      )}
+    </div>
       <button
         type="button"
         onClick={onVote}

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -122,7 +122,7 @@ export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
             <span>{option.label}</span>
             <button
               type="button"
-              className="text-[11px] font-semibold text-[#5856D6]"
+              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
               onClick={() => setSelectedOptionId(option.id)}
             >
               {option.count}명

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -27,39 +27,89 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
   </div>
 );
 
-export const TextVoteBefore: React.FC<{ vote: Vote; onVote: () => void }> = ({ vote, onVote }) => (
-  <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-    <div className="mt-3 flex flex-col gap-3">
-      {vote.options.map((option) => (
-        <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
-          <input type="radio" name={`text-vote-${vote.id}`} className="h-4 w-4 text-[#5856D6]" />
-          {option.label}
-        </label>
-      ))}
-    </div>
-    <div className="mt-4 rounded-xl bg-white px-4 py-3">
-      <label className="text-[11px] font-semibold text-[#8E8E93]">텍스트 추가</label>
-      <input
-        type="text"
-        placeholder="텍스트 입력"
-        className="mt-2 w-full rounded-lg border border-[#E5E5EA] px-3 py-2 text-xs text-[#1C1C1E]"
-      />
+export const TextVoteBefore: React.FC<{
+  vote: Vote;
+  selectedOptionIds: string[];
+  onToggleOption: (optionId: string) => void;
+  onVote: () => void;
+  onAddOption: (label: string) => void;
+}> = ({ vote, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+  const [isAdding, setIsAdding] = useState(false);
+  const [newOption, setNewOption] = useState("");
+
+  const handleAdd = () => {
+    if (!newOption.trim()) return;
+    onAddOption(newOption.trim());
+    setNewOption("");
+    setIsAdding(false);
+  };
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+      <div className="mt-3 flex flex-col gap-3">
+        {vote.options.map((option) => (
+          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+            <input
+              type="checkbox"
+              checked={selectedOptionIds.includes(option.id)}
+              onChange={() => onToggleOption(option.id)}
+              className="h-4 w-4 text-[#5856D6]"
+            />
+            {option.label}
+          </label>
+        ))}
+      </div>
+      <div className="mt-4 rounded-xl bg-white px-4 py-3">
+        <label className="text-[11px] font-semibold text-[#8E8E93]">텍스트 추가</label>
+        {!isAdding ? (
+          <button
+            type="button"
+            onClick={() => setIsAdding(true)}
+            className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+          >
+            항목 추가하기
+          </button>
+        ) : (
+          <div className="mt-2 space-y-2">
+            <input
+              type="text"
+              value={newOption}
+              onChange={(event) => setNewOption(event.target.value)}
+              placeholder="텍스트 입력"
+              className="w-full rounded-lg border border-[#E5E5EA] bg-[#F9F9FB] px-3 py-2 text-xs font-semibold text-[#4C4ACB] focus:border-[#FFE607] focus:outline-none"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleAdd}
+                className="flex-1 rounded-[12px] bg-[#5856D6] px-3 py-2 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+              >
+                추가하기
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setIsAdding(false);
+                  setNewOption("");
+                }}
+                className="flex-1 rounded-[12px] border border-[#E5E5EA] bg-white px-3 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+              >
+                취소
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
       <button
         type="button"
-        className="mt-3 w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+        onClick={onVote}
+        className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
       >
-        항목 추가하기
+        투표하기
       </button>
     </div>
-    <button
-      type="button"
-      onClick={onVote}
-      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-    >
-      투표하기
-    </button>
-  </div>
-);
+  );
+};
 
 export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ vote, onRevote }) => {
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -13,14 +13,7 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
         }`}
       >
-        <div className="flex items-center gap-2">
-          <span>{option.label}</span>
-          {highlightVoted && option.voted && (
-            <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
-              내가 투표함
-            </span>
-          )}
-        </div>
+        <span>{option.label}</span>
         <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
       </div>
     ))}
@@ -29,11 +22,12 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
 
 export const TextVoteBefore: React.FC<{
   vote: Vote;
+  allowDuplicate: boolean;
   selectedOptionIds: string[];
   onToggleOption: (optionId: string) => void;
   onVote: () => void;
   onAddOption: (label: string) => void;
-}> = ({ vote, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+}> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
   const [isAdding, setIsAdding] = useState(false);
   const [newOption, setNewOption] = useState("");
 
@@ -50,7 +44,8 @@ export const TextVoteBefore: React.FC<{
         {vote.options.map((option) => (
           <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
             <input
-              type="checkbox"
+              type={allowDuplicate ? "checkbox" : "radio"}
+              name={allowDuplicate ? undefined : `text-vote-${vote.id}`}
               checked={selectedOptionIds.includes(option.id)}
               onChange={() => onToggleOption(option.id)}
               className="h-4 w-4 text-[#5856D6]"
@@ -60,7 +55,6 @@ export const TextVoteBefore: React.FC<{
         ))}
       </div>
     <div className="mt-4 space-y-2">
-      <label className="text-[11px] font-semibold text-[#8E8E93]">텍스트 추가</label>
       {!isAdding ? (
         <button
           type="button"
@@ -125,14 +119,7 @@ export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
               option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
             }`}
           >
-            <div className="flex items-center gap-2">
-              <span>{option.label}</span>
-              {option.voted && (
-                <span className="rounded-full bg-[#EAE9FF] px-2 py-[2px] text-[10px] font-semibold text-[#4C4ACB]">
-                  내가 투표함
-                </span>
-              )}
-            </div>
+            <span>{option.label}</span>
             <button
               type="button"
               className="text-[11px] font-semibold text-[#5856D6]"

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -7,7 +7,7 @@ const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boole
     {options.map((option) => (
       <div
         key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
+        className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
           highlightVoted && option.voted
             ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
             : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
@@ -42,7 +42,7 @@ export const TextVoteBefore: React.FC<{
     <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
       <div className="mt-3 flex flex-col gap-3">
         {vote.options.map((option) => (
-          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+          <label key={option.id} className="flex items-center gap-3 rounded-xl bg-white px-4 py-2 text-xs text-[#1C1C1E]">
             <input
               type={allowDuplicate ? "checkbox" : "radio"}
               name={allowDuplicate ? undefined : `text-vote-${vote.id}`}
@@ -59,7 +59,7 @@ export const TextVoteBefore: React.FC<{
         <button
           type="button"
           onClick={() => setIsAdding(true)}
-          className="w-full rounded-[12px] border border-[#5856D6] px-3 py-2 text-xs font-semibold text-[#5856D6]"
+          className="w-full rounded-[12px] bg-[#EAE9FF] px-3 py-2 text-xs font-semibold text-[#5856D6]"
         >
           항목 추가하기
         </button>
@@ -115,9 +115,9 @@ export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
         {vote.options.map((option) => (
           <div
             key={option.id}
-            className={`flex items-center justify-between rounded-xl border px-4 py-3 text-xs font-medium ${
-              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-            }`}
+          className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
+            option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+          }`}
           >
             <span>{option.label}</span>
             <button

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -530,112 +530,124 @@ const PostDetailPage: React.FC = () => {
 
           <div>
             {participationVote ? (
-              <div className="rounded-[20px] bg-white p-5 shadow-sm">
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <h3 className="text-base font-semibold text-[#1C1C1E]">참여 여부</h3>
+              participationVote.activeYn === "N" ? (
+                <div className="space-y-3">
+                  <div className="rounded-[16px] bg-[#F9F9FB] px-4 py-3 text-sm font-semibold text-[#5856D6]">
+                    {participationVote.yesCount >= participationVote.noCount ? "참여" : "불참"}
                   </div>
-                  {participationVote.activeYn !== "N" && (
+                  <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
+                    <p className="text-[11px] font-semibold text-[#5856D6]">참여자 이름 목록</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {participationVote.yesMembers.length > 0 ? (
+                        participationVote.yesMembers.map((member) => (
+                          <span
+                            key={`participant-${member.name}`}
+                            className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 text-[10px] font-semibold text-[#5856D6]"
+                          >
+                            {member.name}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="text-[10px]">참여자가 없습니다.</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-[20px] bg-white p-5 shadow-sm">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-base font-semibold text-[#1C1C1E]">참여 여부</h3>
+                    </div>
                     <button
                       onClick={handleEndParticipationVote}
                       className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
                     >
                       투표 종료
                     </button>
+                  </div>
+
+                  {participationVote.hasVoted ? (
+                    <div className="mt-4 rounded-[16px] border border-[#E5E5EA] bg-white p-4">
+                      <div className="flex flex-col gap-2 text-xs text-[#1C1C1E]">
+                        <div
+                          className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
+                            participationVotedChoice === "yes"
+                              ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+                              : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+                          }`}
+                        >
+                          <span>참여</span>
+                          <button
+                            type="button"
+                            onClick={() => setParticipationPopupMembers(participationVote.yesMembers)}
+                            className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
+                          >
+                            {participationVote.yesCount}명
+                          </button>
+                        </div>
+                        <div
+                          className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
+                            participationVotedChoice === "no"
+                              ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+                              : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+                          }`}
+                        >
+                          <span>불참</span>
+                          <button
+                            type="button"
+                            onClick={() => setParticipationPopupMembers(participationVote.noMembers)}
+                            className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
+                          >
+                            {participationVote.noCount}명
+                          </button>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setParticipationChoice(participationVotedChoice);
+                          setParticipationVote((prev) => (prev ? { ...prev, hasVoted: false } : prev));
+                        }}
+                        className="mt-4 w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
+                      >
+                        다시 투표하기
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="mt-4 rounded-[16px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+                      <div className="flex flex-col gap-3">
+                        <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+                          <input
+                            type="radio"
+                            name="participation"
+                            checked={participationChoice === "yes"}
+                            className="h-4 w-4 text-[#5856D6]"
+                            onChange={() => setParticipationChoice("yes")}
+                          />
+                          참여
+                        </label>
+                        <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+                          <input
+                            type="radio"
+                            name="participation"
+                            checked={participationChoice === "no"}
+                            className="h-4 w-4 text-[#5856D6]"
+                            onChange={() => setParticipationChoice("no")}
+                          />
+                          불참
+                        </label>
+                      </div>
+                      <button
+                        className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+                        onClick={handleParticipationVote}
+                      >
+                        투표하기
+                      </button>
+                    </div>
                   )}
                 </div>
-
-                {participationVote.activeYn === "N" ? (
-                  <div className="mt-3 rounded-[16px] bg-[#F9F9FB] p-4 text-xs text-[#1C1C1E]">
-                    <p className="flex items-center justify-between py-1">
-                      <span>참여</span>
-                      <span className="font-semibold text-[#8E8E93]">{participationVote.yesCount}명</span>
-                    </p>
-                    <p className="flex items-center justify-between py-1">
-                      <span>불참</span>
-                      <span className="font-semibold text-[#8E8E93]">{participationVote.noCount}명</span>
-                    </p>
-                  </div>
-                ) : participationVote.hasVoted ? (
-                  <div className="mt-4 rounded-[16px] border border-[#E5E5EA] bg-white p-4">
-                    <div className="flex flex-col gap-2 text-xs text-[#1C1C1E]">
-                      <div
-                        className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
-                          participationVotedChoice === "yes"
-                            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
-                            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-                        }`}
-                      >
-                        <span>참여</span>
-                        <button
-                          type="button"
-                          onClick={() => setParticipationPopupMembers(participationVote.yesMembers)}
-                          className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
-                        >
-                          {participationVote.yesCount}명
-                        </button>
-                      </div>
-                      <div
-                        className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
-                          participationVotedChoice === "no"
-                            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
-                            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-                        }`}
-                      >
-                        <span>불참</span>
-                        <button
-                          type="button"
-                          onClick={() => setParticipationPopupMembers(participationVote.noMembers)}
-                          className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
-                        >
-                          {participationVote.noCount}명
-                        </button>
-                      </div>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setParticipationChoice(participationVotedChoice);
-                        setParticipationVote((prev) => (prev ? { ...prev, hasVoted: false } : prev));
-                      }}
-                      className="mt-4 w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
-                    >
-                      다시 투표하기
-                    </button>
-                  </div>
-                ) : (
-                  <div className="mt-4 rounded-[16px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-                    <div className="flex flex-col gap-3">
-                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
-                        <input
-                          type="radio"
-                          name="participation"
-                          checked={participationChoice === "yes"}
-                          className="h-4 w-4 text-[#5856D6]"
-                          onChange={() => setParticipationChoice("yes")}
-                        />
-                        참여
-                      </label>
-                      <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
-                        <input
-                          type="radio"
-                          name="participation"
-                          checked={participationChoice === "no"}
-                          className="h-4 w-4 text-[#5856D6]"
-                          onChange={() => setParticipationChoice("no")}
-                        />
-                        불참
-                      </label>
-                    </div>
-                    <button
-                      className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-                      onClick={handleParticipationVote}
-                    >
-                      투표하기
-                    </button>
-                  </div>
-                )}
-              </div>
+              )
             ) : (
               <div className="rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-5 text-xs text-[#8E8E93]">
                 참여 여부 투표를 생성하면 참여 여부를 모을 수 있습니다.

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -462,15 +462,7 @@ const PostDetailPage: React.FC = () => {
     <div className="min-h-screen w-full bg-[#F2F2F7]">
       <div className="mx-auto flex w-full max-w-screen-sm flex-col gap-5 px-4 pb-24 pt-6">
         <header className="rounded-[20px] bg-white p-5 shadow-sm">
-          <span className="rounded-full bg-[#E1F0FF] px-3 py-1 text-[11px] font-semibold tracking-wide text-[#1E3A8A]">
-            게시글 상세
-          </span>
-          <h1 className="mt-4 text-left text-xl font-bold text-[#1C1C1E]">{postDetail.title}</h1>
-          <div className="mt-2 flex items-center gap-2 text-xs text-[#8E8E93]">
-            <span>{postDetail.authorName}</span>
-            <span>•</span>
-            <span>{postDetail.createdAt}</span>
-          </div>
+          <h1 className="text-left text-xl font-bold text-[#1C1C1E]">{postDetail.title}</h1>
           <p className="mt-4 text-sm text-[#1C1C1E]">{postDetail.content}</p>
         </header>
 
@@ -481,23 +473,19 @@ const PostDetailPage: React.FC = () => {
 
               return (
                 <div key={vote.id} className="rounded-[20px] bg-white p-5 shadow-sm">
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
-                      {!isClosed && vote.deadline && (
-                        <p className="mt-1 text-xs font-semibold text-[#8E8E93]">투표 마감일: {vote.deadline}</p>
-                      )}
-                      {!isClosed && vote.allowDuplicate && (
-                        <p className="mt-1 text-[11px] font-semibold text-[#5856D6]">중복 투표 가능</p>
-                      )}
-                    </div>
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
                     {!isClosed && (
-                      <button
-                        onClick={() => handleEndVote(vote.id)}
-                        className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
-                      >
-                        투표 종료
-                      </button>
+                      <div className="flex items-center gap-2 text-[11px] font-semibold text-[#8E8E93]">
+                        {vote.deadline && <span>{vote.deadline.split(" ")[0]}</span>}
+                        {vote.allowDuplicate && <span>중복 가능</span>}
+                        <button
+                          onClick={() => handleEndVote(vote.id)}
+                          className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
+                        >
+                          투표 종료
+                        </button>
+                      </div>
                     )}
                   </div>
 
@@ -516,41 +504,37 @@ const PostDetailPage: React.FC = () => {
         </section>
 
         <section className="space-y-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-base font-semibold text-[#1C1C1E]">참여 여부 투표</h2>
-            {!participationVote && (
-              <button
-                onClick={handleCreateParticipationVote}
-                className="rounded-[16px] border border-[#5856D6] px-4 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#4C4ACB]"
-              >
-                참여 여부 투표 생성하기
-              </button>
-            )}
-          </div>
+          {(!participationVote || participationVote.activeYn !== "N") && (
+            <div className="flex items-center justify-between">
+              <h2 className="text-base font-semibold text-[#1C1C1E]">참여 여부 투표</h2>
+              {!participationVote && (
+                <button
+                  onClick={handleCreateParticipationVote}
+                  className="rounded-[16px] border border-[#5856D6] px-4 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#4C4ACB]"
+                >
+                  참여 여부 투표 생성하기
+                </button>
+              )}
+            </div>
+          )}
 
           <div>
             {participationVote ? (
               participationVote.activeYn === "N" ? (
-                <div className="space-y-3">
-                  <div className="rounded-[16px] bg-[#F9F9FB] px-4 py-3 text-sm font-semibold text-[#5856D6]">
-                    {participationVote.yesCount >= participationVote.noCount ? "참여" : "불참"}
-                  </div>
-                  <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
-                    <p className="text-[11px] font-semibold text-[#5856D6]">참여자 이름 목록</p>
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      {participationVote.yesMembers.length > 0 ? (
-                        participationVote.yesMembers.map((member) => (
-                          <span
-                            key={`participant-${member.name}`}
-                            className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 text-[10px] font-semibold text-[#5856D6]"
-                          >
-                            {member.name}
-                          </span>
-                        ))
-                      ) : (
-                        <span className="text-[10px]">참여자가 없습니다.</span>
-                      )}
-                    </div>
+                <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
+                  <div className="flex flex-wrap gap-2">
+                    {participationVote.yesMembers.length > 0 ? (
+                      participationVote.yesMembers.map((member) => (
+                        <span
+                          key={`participant-${member.name}`}
+                          className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 text-[10px] font-semibold text-[#5856D6]"
+                        >
+                          {member.name}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="text-[10px]">참여자가 없습니다.</span>
+                    )}
                   </div>
                 </div>
               ) : (

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -494,7 +494,7 @@ const PostDetailPage: React.FC = () => {
                     {!isClosed && (
                       <button
                         onClick={() => handleEndVote(vote.id)}
-                        className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
+                        className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
                       >
                         투표 종료
                       </button>
@@ -538,7 +538,7 @@ const PostDetailPage: React.FC = () => {
                   {participationVote.activeYn !== "N" && (
                     <button
                       onClick={handleEndParticipationVote}
-                      className="rounded-full border border-[#E5E5EA] px-3 py-1 text-[11px] font-semibold text-[#8E8E93]"
+                      className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
                     >
                       투표 종료
                     </button>
@@ -570,20 +570,10 @@ const PostDetailPage: React.FC = () => {
                         <button
                           type="button"
                           onClick={() => setParticipationPopupMembers(participationVote.yesMembers)}
-                          className="text-[11px] font-semibold text-[#5856D6]"
+                          className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
                         >
                           {participationVote.yesCount}명
                         </button>
-                      </div>
-                      <div className="flex flex-wrap gap-2 px-2 text-[10px] text-[#8E8E93]">
-                        {participationVote.yesMembers.slice(0, 5).map((member) => (
-                          <span
-                            key={`yes-preview-${member.name}`}
-                            className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 font-semibold text-[#5856D6]"
-                          >
-                            {member.name}
-                          </span>
-                        ))}
                       </div>
                       <div
                         className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
@@ -596,20 +586,10 @@ const PostDetailPage: React.FC = () => {
                         <button
                           type="button"
                           onClick={() => setParticipationPopupMembers(participationVote.noMembers)}
-                          className="text-[11px] font-semibold text-[#5856D6]"
+                          className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
                         >
                           {participationVote.noCount}명
                         </button>
-                      </div>
-                      <div className="flex flex-wrap gap-2 px-2 text-[10px] text-[#8E8E93]">
-                        {participationVote.noMembers.slice(0, 5).map((member) => (
-                          <span
-                            key={`no-preview-${member.name}`}
-                            className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 font-semibold text-[#5856D6]"
-                          >
-                            {member.name}
-                          </span>
-                        ))}
                       </div>
                     </div>
                     <button

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -483,10 +483,10 @@ const PostDetailPage: React.FC = () => {
                       </button>
                     </div>
                   )}
-                  <div className="mt-2 flex items-center justify-between">
+                  <div className="mt-2 flex items-start justify-between">
                     <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
                     {!isClosed && (
-                      <div className="flex items-center gap-2 text-[11px] font-semibold text-[#8E8E93]">
+                      <div className="flex flex-col items-end gap-1 text-[11px] font-semibold text-[#8E8E93]">
                         {vote.deadline && (
                           <span>마감일 : {vote.deadline.split(" ")[0].replace(/-/g, ".")}</span>
                         )}
@@ -527,21 +527,25 @@ const PostDetailPage: React.FC = () => {
           <div>
             {participationVote ? (
               participationVote.activeYn === "N" ? (
-                <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
-                  {participantCountText && <p className="mb-2 text-[11px] font-semibold text-[#5856D6]">{participantCountText}</p>}
-                  <div className="flex flex-wrap gap-2">
-                    {participationVote.yesMembers.length > 0 ? (
-                      participationVote.yesMembers.map((member) => (
-                        <span
-                          key={`participant-${member.name}`}
-                          className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 text-[10px] font-semibold text-[#5856D6]"
-                        >
-                          {member.name}
-                        </span>
-                      ))
-                    ) : (
-                      <span className="text-[10px]">참여자가 없습니다.</span>
-                    )}
+                <div className="space-y-2">
+                  {participantCountText && (
+                    <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>
+                  )}
+                  <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
+                    <div className="flex flex-wrap gap-2">
+                      {participationVote.yesMembers.length > 0 ? (
+                        participationVote.yesMembers.map((member) => (
+                          <span
+                            key={`participant-${member.name}`}
+                            className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 text-[10px] font-semibold text-[#5856D6]"
+                          >
+                            {member.name}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="text-[10px]">참여자가 없습니다.</span>
+                      )}
+                    </div>
                   </div>
                 </div>
               ) : (

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -473,18 +473,24 @@ const PostDetailPage: React.FC = () => {
 
               return (
                 <div key={vote.id} className="rounded-[20px] bg-white p-5 shadow-sm">
-                  <div className="flex items-center justify-between">
+                  {!isClosed && (
+                    <div className="flex justify-end">
+                      <button
+                        onClick={() => handleEndVote(vote.id)}
+                        className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
+                      >
+                        투표 종료
+                      </button>
+                    </div>
+                  )}
+                  <div className="mt-2 flex items-center justify-between">
                     <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
                     {!isClosed && (
                       <div className="flex items-center gap-2 text-[11px] font-semibold text-[#8E8E93]">
-                        {vote.deadline && <span>{vote.deadline.split(" ")[0]}</span>}
+                        {vote.deadline && (
+                          <span>마감일 : {vote.deadline.split(" ")[0].replace(/-/g, ".")}</span>
+                        )}
                         {vote.allowDuplicate && <span>중복 가능</span>}
-                        <button
-                          onClick={() => handleEndVote(vote.id)}
-                          className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
-                        >
-                          투표 종료
-                        </button>
                       </div>
                     )}
                   </div>
@@ -522,6 +528,7 @@ const PostDetailPage: React.FC = () => {
             {participationVote ? (
               participationVote.activeYn === "N" ? (
                 <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
+                  {participantCountText && <p className="mb-2 text-[11px] font-semibold text-[#5856D6]">{participantCountText}</p>}
                   <div className="flex flex-wrap gap-2">
                     {participationVote.yesMembers.length > 0 ? (
                       participationVote.yesMembers.map((member) => (
@@ -639,7 +646,9 @@ const PostDetailPage: React.FC = () => {
             )}
           </div>
 
-          {participantCountText && <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>}
+          {!participationVote || participationVote.activeYn !== "N" ? (
+            participantCountText && <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>
+          ) : null}
         </section>
 
         {postDetail.isAuthor && (

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -17,4 +17,5 @@ export type Vote = {
   activeYn: "Y" | "N";
   status: VoteStatus;
   options: VoteOption[];
+  deadline?: string;
 };

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -18,4 +18,5 @@ export type Vote = {
   status: VoteStatus;
   options: VoteOption[];
   deadline?: string;
+  allowDuplicate?: boolean;
 };


### PR DESCRIPTION
### Motivation
- Implement richer voting interactions on the post detail page so users can add options and vote with date/time granularity.
- Allow multiple selections per vote where appropriate and make it possible to re-vote (including participation vote).
- Follow the existing meeting-vote creation UX by providing a modal to create new votes with title, type and deadline.
- Surface vote deadlines in the vote list to make finish times visible.

### Description
- Added `deadline?: string` to the `Vote` type and display `투표 마감일` when present in the vote card via `PostDetail.tsx`.
- Reworked `DateVoteBefore`, `PlaceVoteBefore`, and `TextVoteBefore` to use checkboxes for multi-select, reveal an input when `항목 추가하기` is clicked, and use `datetime-local` for date entries; each component now accepts `selectedOptionIds`, `onToggleOption`, `onAddOption`, and `onVote` props.
- Implemented selection and option-add logic in `PostDetail.tsx` with `selectedOptions`, `handleToggleOption`, `handleAddOption`, updated `handleVote` to mark counts/voted flags on selected options, and `handleRevote` to reset selections; participation vote now records `participationVotedChoice` and supports revoting.
- Added a vote creation modal in `PostDetail.tsx` with `newVoteTitle`, `newVoteType`, and `newVoteDeadline` and `handleAddVote` to insert a new vote into the list.

### Testing
- Launched the dev server with `npm run dev` and the Vite server reported ready (local/network URLs) which succeeded.
- Ran an automated Playwright screenshot attempt to load `/post/1`, but it failed with `ERR_CONNECTION_REFUSED` while trying to connect to `http://localhost:4173/post/1`.
- No unit or integration test suites were executed as part of this change.
- The changes were built and committed locally (no further automated CI run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa03112d88324b98a49690b9a8ee7)