### PR TITLE
Prevent infinite refetch loop in query client

### DIFF
--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -51,11 +51,8 @@ type RawPostDetailResponse = {
   id?: string | number;
   title?: string;
   content?: string;
-  canEdit?: boolean;
-  isAuthor?: boolean | string;
-  isVoteClosed?: boolean;
+  author?: boolean | string;
   voteClosed?: boolean;
-  isVoteEnd?: boolean;
 };
 
 type PostDetailApiResponse = {
@@ -69,11 +66,9 @@ export const fetchPostDetail = async (postId: string): Promise<PostDetailRespons
   const payload = (response as PostDetailApiResponse)?.data ?? (response as RawPostDetailResponse) ?? {};
 
   const id = payload.id != null ? String(payload.id) : postId;
-  const canEdit =
-    typeof payload.isAuthor === "string"
-      ? payload.isAuthor === "true"
-      : Boolean(payload.isAuthor ?? payload.canEdit);
-  const isVoteClosed = Boolean(payload.isVoteClosed ?? payload.voteClosed ?? payload.isVoteEnd);
+  console.log(typeof payload.author)
+  const canEdit = Boolean(payload.author);
+  const isVoteClosed = Boolean(payload.voteClosed ?? payload.voteClosed);
 
   postDetailStore = new PostDetailResponse(
     id,

--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -32,68 +32,10 @@ const resolveWinner = (vote: VoteItemResponse): string | null => {
   return sorted[0]?.value ?? null;
 };
 
-let postDetailStore = new PostDetailResponse(
-  "post-1",
-  "팀 빌딩 회의 일정 잡기",
-  "이번 주 금요일까지 가능한 시간과 장소를 투표해주세요.",
-  true,
-  false,
-);
+let postDetailStore = new PostDetailResponse("", "", "", false, false);
+let voteStore: VoteItemResponse[] = [];
 
-let voteStore: VoteItemResponse[] = [
-  new VoteItemResponse(
-    "vote-1",
-    "회의 날짜 투표",
-    false,
-    "2024-05-24 18:00",
-    true,
-    "date",
-    null,
-    "before",
-    [
-      new VoteOptionResponse("d1", "5/25(토)", false, ["지민", "서연", "태호", "윤아"]),
-      new VoteOptionResponse("d2", "5/26(일)", false, ["도현", "현수"]),
-      new VoteOptionResponse("d3", "5/27(월)", false, ["소영", "민재", "지원", "민호", "유진", "가영"]),
-    ],
-  ),
-  new VoteItemResponse(
-    "vote-2",
-    "회의 장소 투표",
-    false,
-    "2024-05-24 20:00",
-    false,
-    "place",
-    null,
-    "after",
-    [
-      new VoteOptionResponse("p1", "강남역 스터디룸", false, ["지민", "서연", "도현", "현수", "유진"]),
-      new VoteOptionResponse("p2", "홍대 카페", true, ["태호", "지원", "윤아"]),
-      new VoteOptionResponse("p3", "온라인", false, ["민재", "민호", "가영", "소영"]),
-    ],
-  ),
-  new VoteItemResponse(
-    "vote-3",
-    "공지용 메시지 톤 투표",
-    true,
-    "2024-05-18 12:00",
-    false,
-    "text",
-    "포멀",
-    "complete",
-    [
-      new VoteOptionResponse(
-        "t1",
-        "포멀",
-        true,
-        ["지민", "서연", "태호", "윤아", "민재", "현수", "지원", "소영"],
-      ),
-      new VoteOptionResponse("t2", "캐주얼", false, ["도현", "유진", "민호", "가영", "지아"]),
-      new VoteOptionResponse("t3", "친근함", false, ["다은", "세진"]),
-    ],
-  ),
-];
-
-const ensurePostId = (postId: string) => {
+const ensurePostDetailStore = (postId: string) => {
   if (postId && postDetailStore.id !== postId) {
     postDetailStore = new PostDetailResponse(
       postId,
@@ -121,17 +63,22 @@ type PostDetailApiResponse = {
 };
 
 export const fetchPostDetail = async (postId: string): Promise<PostDetailResponse> => {
-  const response = await server.get<PostDetailApiResponse>(`/post/${postId}`);
-  const data = response.data ?? {};
+  ensurePostDetailStore(postId);
 
-  const id = data.id != null ? String(data.id) : postId;
-  const canEdit = typeof data.isAuthor === "string" ? data.isAuthor === "true" : Boolean(data.isAuthor ?? data.canEdit);
-  const isVoteClosed = Boolean(data.isVoteClosed ?? data.voteClosed ?? data.isVoteEnd);
+  const response = await server.get<PostDetailApiResponse>(`/post/${postId}`);
+  const payload = (response as PostDetailApiResponse)?.data ?? (response as RawPostDetailResponse) ?? {};
+
+  const id = payload.id != null ? String(payload.id) : postId;
+  const canEdit =
+    typeof payload.isAuthor === "string"
+      ? payload.isAuthor === "true"
+      : Boolean(payload.isAuthor ?? payload.canEdit);
+  const isVoteClosed = Boolean(payload.isVoteClosed ?? payload.voteClosed ?? payload.isVoteEnd);
 
   postDetailStore = new PostDetailResponse(
     id,
-    data.title ?? postDetailStore.title,
-    data.content ?? postDetailStore.content,
+    payload.title ?? postDetailStore.title,
+    payload.content ?? postDetailStore.content,
     canEdit,
     isVoteClosed,
   );
@@ -146,12 +93,82 @@ export const fetchPostDetail = async (postId: string): Promise<PostDetailRespons
 };
 
 export const fetchVoteList = async (postId: string): Promise<VoteListResponse> => {
-  ensurePostId(postId);
-  await delay();
-  if (postDetailStore.isVoteClosed) {
-    return new VoteListResponse([]);
-  }
-  return cloneVotes(voteStore);
+  type VoteOptionApiResponse = {
+    id?: string | number;
+    voteOptionId?: string | number;
+    value?: string;
+    optionValue?: string;
+    optionName?: string;
+    isVoted?: boolean;
+    voted?: boolean;
+    voters?: string[];
+    voterList?: string[];
+  };
+
+  type VoteApiResponse = {
+    id?: string | number;
+    voteId?: string | number;
+    title?: string;
+    voteTitle?: string;
+    deadline?: string | null;
+    voteDeadline?: string | null;
+    allowDuplicate?: boolean;
+    duplicateYn?: boolean | string;
+    isClosed?: boolean;
+    voteClosed?: boolean;
+    activeYn?: "Y" | "N";
+    type?: VoteType;
+    voteType?: VoteType;
+    result?: string | null;
+    resultOption?: string | null;
+    status?: VoteStatus;
+    voteStatus?: VoteStatus;
+    options?: VoteOptionApiResponse[];
+    voteOptions?: VoteOptionApiResponse[];
+  };
+
+  type VoteListApiResponse = { data?: VoteApiResponse[] } | VoteApiResponse[];
+
+  ensurePostDetailStore(postId);
+
+  const response = await server.get<VoteListApiResponse>("/vote/list", {
+    params: { postId },
+  });
+
+  const voteData = (response as { data?: VoteApiResponse[] })?.data ?? (response as VoteApiResponse[]) ?? [];
+
+  const votes = voteData.map((vote) => {
+    const options = (vote.options ?? vote.voteOptions ?? []).map((option) => {
+      const id = option.id ?? option.voteOptionId;
+      const value = option.value ?? option.optionValue ?? option.optionName ?? "";
+      const voters = option.voters ?? option.voterList ?? [];
+      return new VoteOptionResponse(id != null ? String(id) : value, value, Boolean(option.isVoted ?? option.voted), voters);
+    });
+
+    const id = vote.id ?? vote.voteId;
+    const type = (vote.type ?? vote.voteType ?? "text") as VoteType;
+    const status = (vote.status ?? vote.voteStatus ?? (vote.activeYn === "N" ? "complete" : "before")) as VoteStatus;
+
+    return new VoteItemResponse(
+      id != null ? String(id) : "",
+      vote.title ?? vote.voteTitle ?? "",
+      Boolean(vote.isClosed ?? vote.voteClosed ?? vote.activeYn === "N"),
+      vote.deadline ?? vote.voteDeadline ?? null,
+      Boolean(
+        typeof vote.duplicateYn === "string"
+          ? vote.duplicateYn === "Y"
+          : vote.allowDuplicate ?? vote.duplicateYn,
+      ),
+      type,
+      vote.result ?? vote.resultOption ?? null,
+      status,
+      options,
+    );
+  });
+
+  voteStore = votes;
+
+  return cloneVotes(votes);
 };
 
 export const addVoteOption = async ({

--- a/src/lib/react-query/index.tsx
+++ b/src/lib/react-query/index.tsx
@@ -29,7 +29,6 @@ export class QueryClient {
     const previous = this.getQueryData<T>(queryKey);
     const next = typeof updater === "function" ? (updater as (old?: T) => T)(previous) : updater;
     this.store.set(serialized, next);
-    this.notify(serialized);
   }
 
   async fetchQuery<TData>({ queryKey, queryFn }: { queryKey: QueryKey; queryFn: () => Promise<TData> }): Promise<TData> {

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -83,10 +83,13 @@ const PostDetailPage: React.FC = () => {
   });
 
   const votes = useMemo(() => mapVoteResponses(voteListResponse), [voteListResponse]);
+  const hasVotes = votes.length > 0;
   const hasActiveVotes = useMemo(() => votes.some((vote) => vote.activeYn === "Y"), [votes]);
   const isLoading = isPostLoading || (postDetail?.isVoteClosed === false && (isVoteLoading || isVoteFetching));
   const canManageVotes = postDetail?.isAuthor === true;
-  const showVoteManagementActions = canManageVotes && (hasActiveVotes || postDetail?.isVoteClosed === true);
+  const showVoteSection = postDetail?.isVoteClosed === false;
+  const showVoteAddButton = canManageVotes && postDetail?.isVoteClosed === false;
+  const showVoteCloseButton = canManageVotes && postDetail?.isVoteClosed === false && hasVotes;
 
   const addVoteOptionMutation = useMutation({
     mutationFn: ({ voteId, optionValue }: { voteId: string; optionValue: string }) => addVoteOption({ voteId, optionValue }),
@@ -380,66 +383,68 @@ const PostDetailPage: React.FC = () => {
           <p className="mt-4 text-sm text-[#1C1C1E]">{postDetail.content}</p>
         </header>
 
-        <section className="space-y-4">
-          <div className="flex flex-col gap-5">
-            {votes.map((vote) => {
-              const isClosed = vote.activeYn === "N";
+        {showVoteSection && (
+          <section className="space-y-4">
+            <div className="flex flex-col gap-5">
+              {votes.map((vote) => {
+                const isClosed = vote.activeYn === "N";
 
-              return (
-                <div key={vote.id} className="rounded-[20px] bg-white p-5 shadow-sm">
-                  {!isClosed && canManageVotes && (
-                    <div className="flex justify-end">
-                      <button
-                        onClick={() => handleEndVote(vote.id)}
-                        className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
-                      >
-                        투표 종료
-                      </button>
-                    </div>
-                  )}
-                  <div className="mt-2 flex items-start justify-between">
-                    <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
-                    {!isClosed && (
-                      <div className="flex flex-col items-end gap-1 text-[11px] font-semibold text-[#8E8E93]">
-                        {vote.deadline && (
-                          <span>마감일 : {vote.deadline.split(" ")[0].replace(/-/g, ".")}</span>
-                        )}
-                        {vote.allowDuplicate && <span>중복 가능</span>}
+                return (
+                  <div key={vote.id} className="rounded-[20px] bg-white p-5 shadow-sm">
+                    {!isClosed && canManageVotes && (
+                      <div className="flex justify-end">
+                        <button
+                          onClick={() => handleEndVote(vote.id)}
+                          className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
+                        >
+                          투표 종료
+                        </button>
                       </div>
                     )}
+                    <div className="mt-2 flex items-start justify-between">
+                      <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
+                      {!isClosed && (
+                        <div className="flex flex-col items-end gap-1 text-[11px] font-semibold text-[#8E8E93]">
+                          {vote.deadline && (
+                            <span>마감일 : {vote.deadline.split(" ")[0].replace(/-/g, ".")}</span>
+                          )}
+                          {vote.allowDuplicate && <span>중복 가능</span>}
+                        </div>
+                      )}
+                    </div>
+
+                    {renderVoteState(vote)}
+                    {voteErrors[vote.id] && (
+                      <p className="mt-2 text-[11px] font-semibold text-[#FF3B30]">{voteErrors[vote.id]}</p>
+                    )}
                   </div>
+                );
+              })}
+            </div>
 
-                  {renderVoteState(vote)}
-                  {voteErrors[vote.id] && (
-                    <p className="mt-2 text-[11px] font-semibold text-[#FF3B30]">{voteErrors[vote.id]}</p>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-
-          {showVoteManagementActions && (
-            <>
-              <button
-                onClick={() => {
-                  setNewVoteErrors({});
-                  setIsVoteModalOpen(true);
-                }}
-                className="w-full rounded-[16px] bg-[#5856D6] px-4 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-              >
-                투표 추가
-              </button>
-              {canManageVotes && (
+            {showVoteAddButton && (
+              <>
                 <button
-                  onClick={handleEndAllVotes}
-                  className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-4 py-3 text-xs font-semibold text-[#5856D6] shadow-sm transition hover:border-[#C7C7CC]"
+                  onClick={() => {
+                    setNewVoteErrors({});
+                    setIsVoteModalOpen(true);
+                  }}
+                  className="w-full rounded-[16px] bg-[#5856D6] px-4 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
                 >
-                  투표 종료
+                  투표 추가
                 </button>
-              )}
-            </>
-          )}
-        </section>
+                {showVoteCloseButton && (
+                  <button
+                    onClick={handleEndAllVotes}
+                    className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-4 py-3 text-xs font-semibold text-[#5856D6] shadow-sm transition hover:border-[#C7C7CC]"
+                  >
+                    투표 종료
+                  </button>
+                )}
+              </>
+            )}
+          </section>
+        )}
 
         {!hasActiveVotes && participationVote && (
           <section className="space-y-4">

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -86,6 +86,7 @@ const PostDetailPage: React.FC = () => {
   const hasActiveVotes = useMemo(() => votes.some((vote) => vote.activeYn === "Y"), [votes]);
   const isLoading = isPostLoading || (postDetail?.isVoteClosed === false && (isVoteLoading || isVoteFetching));
   const canManageVotes = postDetail?.isAuthor === true;
+  const showVoteManagementActions = canManageVotes && (hasActiveVotes || postDetail?.isVoteClosed === true);
 
   const addVoteOptionMutation = useMutation({
     mutationFn: ({ voteId, optionValue }: { voteId: string; optionValue: string }) => addVoteOption({ voteId, optionValue }),
@@ -417,7 +418,7 @@ const PostDetailPage: React.FC = () => {
             })}
           </div>
 
-          {hasActiveVotes && canManageVotes && (
+          {showVoteManagementActions && (
             <>
               <button
                 onClick={() => {
@@ -570,7 +571,7 @@ const PostDetailPage: React.FC = () => {
           </section>
         )}
 
-        {postDetail.isAuthor && (
+        {canManageVotes && (
           <div className="grid grid-cols-2 gap-3">
             <button
               onClick={() => navigate(`/meet/edit/${postDetail.id}`)}

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import FooterNav from "../components/FooterNav";
@@ -32,17 +32,6 @@ type ParticipationVote = {
   noMembers: { name: string }[];
 };
 
-const initialParticipationVote: ParticipationVote = {
-  id: "participation-1",
-  activeYn: "Y",
-  hasVoted: false,
-  yesCount: 4,
-  noCount: 1,
-  participantCount: 0,
-  yesMembers: [{ name: "지민" }, { name: "서연" }, { name: "태호" }, { name: "윤아" }],
-  noMembers: [{ name: "현수" }],
-};
-
 const mapVoteResponses = (response?: VoteListResponse): Vote[] => {
   if (!response) return [];
   return response.votes.map((vote) => ({
@@ -68,10 +57,11 @@ const PostDetailPage: React.FC = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const [participationVote, setParticipationVote] = useState<ParticipationVote | null>(initialParticipationVote);
+  const [participationVote, setParticipationVote] = useState<ParticipationVote | null>(null);
   const [participationChoice, setParticipationChoice] = useState<"yes" | "no" | null>(null);
   const [participationVotedChoice, setParticipationVotedChoice] = useState<"yes" | "no" | null>(null);
   const [selectedOptions, setSelectedOptions] = useState<Record<string, string[]>>({});
+  const [voteErrors, setVoteErrors] = useState<Record<string, string>>({});
   const [participationPopupMembers, setParticipationPopupMembers] = useState<{ name: string }[] | null>(null);
   const [isVoteModalOpen, setIsVoteModalOpen] = useState(false);
   const [newVoteTitle, setNewVoteTitle] = useState("");
@@ -95,10 +85,6 @@ const PostDetailPage: React.FC = () => {
   const votes = useMemo(() => mapVoteResponses(voteListResponse), [voteListResponse]);
   const hasActiveVotes = useMemo(() => votes.some((vote) => vote.activeYn === "Y"), [votes]);
   const isLoading = isPostLoading || (postDetail?.isVoteClosed === false && (isVoteLoading || isVoteFetching));
-
-  useEffect(() => {
-    setParticipationVote(initialParticipationVote);
-  }, []);
 
   const addVoteOptionMutation = useMutation({
     mutationFn: ({ voteId, optionValue }: { voteId: string; optionValue: string }) => addVoteOption({ voteId, optionValue }),
@@ -130,12 +116,6 @@ const PostDetailPage: React.FC = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["postVotes", postId] });
       queryClient.invalidateQueries({ queryKey: ["postDetail", postId] });
-      setParticipationVote((prev) =>
-        prev ?? {
-          ...initialParticipationVote,
-          id: `participation-${Date.now()}`,
-        },
-      );
     },
   });
 
@@ -163,7 +143,16 @@ const PostDetailPage: React.FC = () => {
 
   const handleVote = (voteId: string) => {
     const optionIds = selectedOptions[voteId] ?? [];
-    if (optionIds.length === 0) return;
+    if (optionIds.length === 0) {
+      setVoteErrors((prev) => ({ ...prev, [voteId]: "투표할 항목을 선택해주세요." }));
+      return;
+    }
+
+    setVoteErrors((prev) => {
+      const updated = { ...prev };
+      delete updated[voteId];
+      return updated;
+    });
     castVoteMutation.mutate({ voteId, optionIds });
   };
 
@@ -181,6 +170,12 @@ const PostDetailPage: React.FC = () => {
   };
 
   const handleToggleOption = (voteId: string, optionId: string) => {
+    setVoteErrors((prev) => {
+      if (!prev[voteId]) return prev;
+      const updated = { ...prev };
+      delete updated[voteId];
+      return updated;
+    });
     setSelectedOptions((prev) => {
       const vote = votes.find((item) => item.id === voteId);
       if (!vote) return prev;
@@ -234,19 +229,6 @@ const PostDetailPage: React.FC = () => {
 
   const handleEndAllVotes = () => {
     closeAllVotesMutation.mutate();
-  };
-
-  const handleCreateParticipationVote = () => {
-    setParticipationVote({
-      id: "participation-2",
-      activeYn: "Y",
-      hasVoted: false,
-      yesCount: 0,
-      noCount: 0,
-      participantCount: 0,
-      yesMembers: [],
-      noMembers: [],
-    });
   };
 
   const handleEndParticipationVote = () => {
@@ -426,6 +408,9 @@ const PostDetailPage: React.FC = () => {
                   </div>
 
                   {renderVoteState(vote)}
+                  {voteErrors[vote.id] && (
+                    <p className="mt-2 text-[11px] font-semibold text-[#FF3B30]">{voteErrors[vote.id]}</p>
+                  )}
                 </div>
               );
             })}
@@ -452,151 +437,131 @@ const PostDetailPage: React.FC = () => {
           )}
         </section>
 
-        {!hasActiveVotes && (
+        {!hasActiveVotes && participationVote && (
           <section className="space-y-4">
-            {(!participationVote || participationVote.activeYn !== "N") && (
-              <div className="flex items-center justify-between">
-                <h2 className="text-base font-semibold text-[#1C1C1E]">참여 여부 투표</h2>
-                {!participationVote && (
-                  <button
-                    onClick={handleCreateParticipationVote}
-                    className="rounded-[16px] border border-[#5856D6] px-4 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#4C4ACB]"
-                  >
-                    참여 여부 투표 생성하기
-                  </button>
-                )}
-              </div>
-            )}
+            <div className="flex items-center justify-between">
+              <h2 className="text-base font-semibold text-[#1C1C1E]">참여 여부 투표</h2>
+            </div>
 
             <div>
-              {participationVote ? (
-                participationVote.activeYn === "N" ? (
-                  <div className="space-y-2">
-                    {participantCountText && (
-                      <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>
-                    )}
-                    <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
-                      <div className="flex flex-wrap gap-2">
-                        {participationVote.yesMembers.length > 0 ? (
-                          participationVote.yesMembers.map((member) => (
-                            <span
-                              key={`participant-${member.name}`}
-                              className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 text-[10px] font-semibold text-[#5856D6]"
-                            >
-                              {member.name}
-                            </span>
-                          ))
-                        ) : (
-                          <span className="text-[10px]">참여자가 없습니다.</span>
-                        )}
-                      </div>
+              {participationVote.activeYn === "N" ? (
+                <div className="space-y-2">
+                  {participantCountText && <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>}
+                  <div className="rounded-[16px] bg-white p-4 text-xs text-[#8E8E93]">
+                    <div className="flex flex-wrap gap-2">
+                      {participationVote.yesMembers.length > 0 ? (
+                        participationVote.yesMembers.map((member) => (
+                          <span
+                            key={`participant-${member.name}`}
+                            className="rounded-full border border-[#E5E5EA] bg-white px-2 py-1 text-[10px] font-semibold text-[#5856D6]"
+                          >
+                            {member.name}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="text-[10px]">참여자가 없습니다.</span>
+                      )}
                     </div>
                   </div>
-                ) : (
-                  <div className="rounded-[20px] bg-white p-5 shadow-sm">
-                    <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <h3 className="text-base font-semibold text-[#1C1C1E]">참여 여부</h3>
+                </div>
+              ) : (
+                <div className="rounded-[20px] bg-white p-5 shadow-sm">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <h3 className="text-base font-semibold text-[#1C1C1E]">참여 여부</h3>
+                    </div>
+                    <button
+                      onClick={handleEndParticipationVote}
+                      className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
+                    >
+                      투표 종료
+                    </button>
+                  </div>
+
+                  {participationVote.hasVoted ? (
+                    <div className="mt-4 rounded-[16px] border border-[#E5E5EA] bg-white p-4">
+                      <div className="flex flex-col gap-2 text-xs text-[#1C1C1E]">
+                        <div
+                          className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
+                            participationVotedChoice === "yes"
+                              ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+                              : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+                          }`}
+                        >
+                          <span>참여</span>
+                          <button
+                            type="button"
+                            onClick={() => setParticipationPopupMembers(participationVote.yesMembers)}
+                            className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
+                          >
+                            {participationVote.yesCount}명
+                          </button>
+                        </div>
+                        <div
+                          className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
+                            participationVotedChoice === "no"
+                              ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
+                              : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+                          }`}
+                        >
+                          <span>불참</span>
+                          <button
+                            type="button"
+                            onClick={() => setParticipationPopupMembers(participationVote.noMembers)}
+                            className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
+                          >
+                            {participationVote.noCount}명
+                          </button>
+                        </div>
                       </div>
                       <button
-                        onClick={handleEndParticipationVote}
-                        className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
+                        type="button"
+                        onClick={() => {
+                          setParticipationChoice(participationVotedChoice);
+                          setParticipationVote((prev) => (prev ? { ...prev, hasVoted: false } : prev));
+                        }}
+                        className="mt-4 w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
                       >
-                        투표 종료
+                        다시 투표하기
                       </button>
                     </div>
-
-                    {participationVote.hasVoted ? (
-                      <div className="mt-4 rounded-[16px] border border-[#E5E5EA] bg-white p-4">
-                        <div className="flex flex-col gap-2 text-xs text-[#1C1C1E]">
-                          <div
-                            className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
-                              participationVotedChoice === "yes"
-                                ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
-                                : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-                            }`}
-                          >
-                            <span>참여</span>
-                            <button
-                              type="button"
-                              onClick={() => setParticipationPopupMembers(participationVote.yesMembers)}
-                              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
-                            >
-                              {participationVote.yesCount}명
-                            </button>
-                          </div>
-                          <div
-                            className={`flex items-center justify-between rounded-xl border px-4 py-2 ${
-                              participationVotedChoice === "no"
-                                ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
-                                : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-                            }`}
-                          >
-                            <span>불참</span>
-                            <button
-                              type="button"
-                              onClick={() => setParticipationPopupMembers(participationVote.noMembers)}
-                              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
-                            >
-                              {participationVote.noCount}명
-                            </button>
-                          </div>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setParticipationChoice(participationVotedChoice);
-                            setParticipationVote((prev) => (prev ? { ...prev, hasVoted: false } : prev));
-                          }}
-                          className="mt-4 w-full rounded-[16px] border border-[#E5E5EA] bg-white px-5 py-2 text-xs font-semibold text-[#5856D6] transition hover:border-[#C7C7CC]"
-                        >
-                          다시 투표하기
-                        </button>
+                  ) : (
+                    <div className="mt-4 rounded-[16px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
+                      <div className="flex flex-col gap-3">
+                        <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+                          <input
+                            type="radio"
+                            name="participation"
+                            checked={participationChoice === "yes"}
+                            className="h-4 w-4 text-[#5856D6]"
+                            onChange={() => setParticipationChoice("yes")}
+                          />
+                          참여
+                        </label>
+                        <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
+                          <input
+                            type="radio"
+                            name="participation"
+                            checked={participationChoice === "no"}
+                            className="h-4 w-4 text-[#5856D6]"
+                            onChange={() => setParticipationChoice("no")}
+                          />
+                          불참
+                        </label>
                       </div>
-                    ) : (
-                      <div className="mt-4 rounded-[16px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
-                        <div className="flex flex-col gap-3">
-                          <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
-                            <input
-                              type="radio"
-                              name="participation"
-                              checked={participationChoice === "yes"}
-                              className="h-4 w-4 text-[#5856D6]"
-                              onChange={() => setParticipationChoice("yes")}
-                            />
-                            참여
-                          </label>
-                          <label className="flex items-center gap-3 rounded-xl bg-white px-4 py-3 text-xs text-[#1C1C1E]">
-                            <input
-                              type="radio"
-                              name="participation"
-                              checked={participationChoice === "no"}
-                              className="h-4 w-4 text-[#5856D6]"
-                              onChange={() => setParticipationChoice("no")}
-                            />
-                            불참
-                          </label>
-                        </div>
-                        <button
-                          className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
-                          onClick={handleParticipationVote}
-                        >
-                          투표하기
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                )
-              ) : (
-                <div className="rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-5 text-xs text-[#8E8E93]">
-                  참여 여부 투표를 생성하면 참여 여부를 모을 수 있습니다.
+                      <button
+                        className="mt-4 w-full rounded-[16px] bg-[#5856D6] px-5 py-3 text-xs font-semibold text-white shadow-sm transition hover:bg-[#4C4ACB]"
+                        onClick={handleParticipationVote}
+                      >
+                        투표하기
+                      </button>
+                    </div>
+                  )}
                 </div>
               )}
             </div>
 
-            {!participationVote || participationVote.activeYn !== "N" ? (
-              participantCountText && <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>
-            ) : null}
+            {participantCountText && <p className="text-sm font-semibold text-[#4C4ACB]">{participantCountText}</p>}
           </section>
         )}
 

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -85,6 +85,7 @@ const PostDetailPage: React.FC = () => {
   const votes = useMemo(() => mapVoteResponses(voteListResponse), [voteListResponse]);
   const hasActiveVotes = useMemo(() => votes.some((vote) => vote.activeYn === "Y"), [votes]);
   const isLoading = isPostLoading || (postDetail?.isVoteClosed === false && (isVoteLoading || isVoteFetching));
+  const canManageVotes = postDetail?.isAuthor === true;
 
   const addVoteOptionMutation = useMutation({
     mutationFn: ({ voteId, optionValue }: { voteId: string; optionValue: string }) => addVoteOption({ voteId, optionValue }),
@@ -385,7 +386,7 @@ const PostDetailPage: React.FC = () => {
 
               return (
                 <div key={vote.id} className="rounded-[20px] bg-white p-5 shadow-sm">
-                  {!isClosed && (
+                  {!isClosed && canManageVotes && (
                     <div className="flex justify-end">
                       <button
                         onClick={() => handleEndVote(vote.id)}
@@ -416,7 +417,7 @@ const PostDetailPage: React.FC = () => {
             })}
           </div>
 
-          {hasActiveVotes && (
+          {hasActiveVotes && canManageVotes && (
             <>
               <button
                 onClick={() => {
@@ -427,12 +428,14 @@ const PostDetailPage: React.FC = () => {
               >
                 투표 추가
               </button>
-              <button
-                onClick={handleEndAllVotes}
-                className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-4 py-3 text-xs font-semibold text-[#5856D6] shadow-sm transition hover:border-[#C7C7CC]"
-              >
-                투표 종료
-              </button>
+              {canManageVotes && (
+                <button
+                  onClick={handleEndAllVotes}
+                  className="w-full rounded-[16px] border border-[#E5E5EA] bg-white px-4 py-3 text-xs font-semibold text-[#5856D6] shadow-sm transition hover:border-[#C7C7CC]"
+                >
+                  투표 종료
+                </button>
+              )}
             </>
           )}
         </section>
@@ -470,12 +473,14 @@ const PostDetailPage: React.FC = () => {
                     <div>
                       <h3 className="text-base font-semibold text-[#1C1C1E]">참여 여부</h3>
                     </div>
-                    <button
-                      onClick={handleEndParticipationVote}
-                      className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
-                    >
-                      투표 종료
-                    </button>
+                    {canManageVotes && (
+                      <button
+                        onClick={handleEndParticipationVote}
+                        className="rounded-full bg-[#EAE9FF] px-3 py-1 text-[11px] font-semibold text-[#5856D6]"
+                      >
+                        투표 종료
+                      </button>
+                    )}
                   </div>
 
                   {participationVote.hasVoted ? (


### PR DESCRIPTION
## Summary
- stop `setQueryData` from notifying subscribers to avoid perpetual refetches when queries update their own cache

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6022a0d483248169d34567fe237f)