### PR TITLE
Ensure vote option additions refresh vote lists

### DIFF
--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -168,8 +168,7 @@ export const addVoteOption = async ({
     },
   );
 
-  const voteData = (response as { data?: VoteItemResponse })?.data ?? (response as VoteItemResponse);
-  const updatedVote = cloneVote(voteData);
+  const updatedVote = (response as { data?: VoteItemResponse })?.data ?? (response as VoteItemResponse);
   voteStore = voteStore.map((vote) => (vote.id === updatedVote.id ? updatedVote : vote));
 
   return updatedVote;

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -104,11 +104,17 @@ const PostDetailPage: React.FC = () => {
   const showVoteCloseButton = canManageVotes && postDetail?.isVoteClosed === false && hasVotes;
 
   const addVoteOptionMutation = useMutation({
-     mutationFn: ({ voteId, optionValue }: { voteId: string; optionValue: string }) => {
+    mutationFn: ({ voteId, optionValue }: { voteId: string; optionValue: string }) => {
       if (!postId) throw new Error("postId is required to add an option");
       return addVoteOption({ voteId, optionValue });
     },
-    onSuccess: async () => {
+    onSuccess: async (updatedVote) => {
+      queryClient.setQueryData<VoteListResponse | undefined>(["postVotes", postId], (prev) => {
+        if (!prev) return prev;
+        const votes = prev.votes.map((vote) => (vote.id === updatedVote.id ? updatedVote : vote));
+        return new VoteListResponse(votes);
+      });
+
       await queryClient.refetchQueries({
         queryKey: ["postVotes", postId],
       });


### PR DESCRIPTION
## Summary
- update vote option mutation to immediately sync the cached vote list when an option is added
- keep vote list queries consistent by refetching after cache update

## Testing
- npm run lint (fails: existing lint errors in unrelated files)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd61b34308324943fff166e6585ea)