### PR TITLE
Handle vote option additions without refetching vote list

### DIFF
--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -383,7 +383,31 @@ export const deleteVoteItem = async ({
   });
 
   const updatedVoteApi = (response as { data?: VoteApiResponse })?.data ?? (response as VoteApiResponse);
-  const updatedVote = mapVoteApiResponseToVoteItem(updatedVoteApi);
+
+  if (updatedVoteApi && Object.keys(updatedVoteApi).length > 0) {
+    const updatedVote = mapVoteApiResponseToVoteItem(updatedVoteApi);
+    voteStore = voteStore.map((vote) => (vote.id === updatedVote.id ? updatedVote : vote));
+
+    return updatedVote;
+  }
+
+  const currentVote = voteStore.find((vote) => String(vote.id) === String(voteId));
+  if (!currentVote) {
+    throw new Error("Unable to update vote after deleting option");
+  }
+
+  const filteredOptions = currentVote.options.filter((option) => String(option.id) !== String(voteItemId));
+  const updatedVote = new VoteItemResponse(
+    currentVote.id,
+    currentVote.title,
+    currentVote.isClosed,
+    currentVote.deadline,
+    currentVote.allowDuplicate,
+    currentVote.type,
+    currentVote.result,
+    currentVote.status,
+    filteredOptions,
+  );
   voteStore = voteStore.map((vote) => (vote.id === updatedVote.id ? updatedVote : vote));
 
   return updatedVote;

--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -19,7 +19,9 @@ const cloneVote = (vote: VoteItemResponse): VoteItemResponse =>
     vote.type,
     vote.result,
     vote.status,
-    vote.options.map((option) => new VoteOptionResponse(option.id, option.value, option.isVoted, [...option.voters])),
+    vote.options.map(
+      (option) => new VoteOptionResponse(option.id, option.value, option.isVoted, [...option.voters], option.editable),
+    ),
   );
 
 const cloneVotes = (votes: VoteItemResponse[]) => new VoteListResponse(votes.map(cloneVote));
@@ -90,6 +92,7 @@ type VoteItemApiResponse = {
   value?: string;
   voted?: boolean;
   voterList?: string[];
+  editable?: boolean | string;
 };
 
 type VoteApiResponse = {
@@ -109,7 +112,15 @@ const mapVoteApiResponseToVoteItem = (vote: VoteApiResponse): VoteItemResponse =
     const id = option.id;
     const value = option.value ?? "";
     const voters = option.voterList ?? [];
-    return new VoteOptionResponse(id != null ? String(id) : value, value, Boolean(option.voted ?? false), voters);
+    const editable = typeof option.editable === "string" ? option.editable === "true" : Boolean(option.editable);
+
+    return new VoteOptionResponse(
+      id != null ? String(id) : value,
+      value,
+      Boolean(option.voted ?? false),
+      voters,
+      editable,
+    );
   });
 
   const id = vote.id;
@@ -299,7 +310,9 @@ export const reopenVote = async (voteId: string): Promise<VoteListResponse> => {
       vote.type,
       vote.result,
       "before",
-      vote.options.map((option) => new VoteOptionResponse(option.id, option.value, option.isVoted, [...option.voters])),
+      vote.options.map(
+        (option) => new VoteOptionResponse(option.id, option.value, option.isVoted, [...option.voters], option.editable),
+      ),
     );
   });
   postDetailStore = new PostDetailResponse(

--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -348,7 +348,7 @@ export const deleteVote = async (voteId: string, postId?: string): Promise<VoteL
     throw new Error("voteId is required to delete a vote");
   }
 
-  await server.delete("/vote/item", { params: { voteId } });
+  await server.delete("/vote", { params: { voteId } });
 
   const targetPostId = postId ?? postDetailStore.id;
   if (!targetPostId) {
@@ -356,4 +356,22 @@ export const deleteVote = async (voteId: string, postId?: string): Promise<VoteL
   }
 
   return fetchVoteList(targetPostId);
+};
+
+export const deleteVoteItem = async ({
+  voteId,
+  voteItemId,
+}: {
+  voteId: string;
+  voteItemId: string;
+}): Promise<VoteItemResponse> => {
+  const response = await server.delete<{ data?: VoteApiResponse }>("/vote/item", {
+    params: { voteItemId, voteId },
+  });
+
+  const updatedVoteApi = (response as { data?: VoteApiResponse })?.data ?? (response as VoteApiResponse);
+  const updatedVote = mapVoteApiResponseToVoteItem(updatedVoteApi);
+  voteStore = voteStore.map((vote) => (vote.id === updatedVote.id ? updatedVote : vote));
+
+  return updatedVote;
 };

--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -243,33 +243,18 @@ export const castVote = async ({
 };
 
 export const closeVote = async (voteId: string): Promise<VoteListResponse> => {
-  await delay();
-  voteStore = voteStore.map((vote) => {
-    if (vote.id !== voteId) return vote;
-    const winner = resolveWinner(vote);
-    return new VoteItemResponse(
-      vote.id,
-      vote.title,
-      true,
-      vote.deadline,
-      vote.allowDuplicate,
-      vote.type,
-      winner,
-      "complete",
-      vote.options,
-    );
-  });
+  if (!voteId) {
+    throw new Error("voteId is required to close a vote");
+  }
 
-  const allClosed = voteStore.every((vote) => vote.isClosed);
-  postDetailStore = new PostDetailResponse(
-    postDetailStore.id,
-    postDetailStore.title,
-    postDetailStore.content,
-    postDetailStore.isAuthor,
-    allClosed,
-  );
+  await server.post("/vote/terminate", { data: { voteId } });
 
-  return cloneVotes(voteStore);
+  const targetPostId = postDetailStore.id;
+  if (!targetPostId) {
+    return cloneVotes([]);
+  }
+
+  return fetchVoteList(targetPostId);
 };
 
 export const closeAllVotes = async (): Promise<VoteListResponse> => {

--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -215,20 +215,20 @@ export const castVote = async ({
 }: {
   voteId: string;
   optionIds: string[];
-}): Promise<VoteListResponse> => {
-  await server.post("/vote/confirm", {
+}): Promise<VoteItemResponse> => {
+  const response = await server.post<{ data?: VoteApiResponse }>("/vote/confirm", {
     data: {
       voteId,
       voteItemIdList: optionIds,
     },
   });
 
-  const targetPostId = postDetailStore.id;
-  if (!targetPostId) {
-    return cloneVotes(voteStore);
-  }
+  const updatedVoteApi = (response as { data?: VoteApiResponse })?.data ?? (response as VoteApiResponse);
+  const updatedVote = mapVoteApiResponseToVoteItem(updatedVoteApi);
 
-  return fetchVoteList(targetPostId);
+  voteStore = voteStore.map((vote) => (vote.id === updatedVote.id ? updatedVote : vote));
+
+  return updatedVote;
 };
 
 export const closeVote = async (voteId: string): Promise<VoteListResponse> => {

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -125,7 +125,7 @@ export const DateVoteBefore: React.FC<{
       <div
         className="flex h-40 w-16 flex-col items-center justify-center text-center text-xs font-semibold text-[#5856D6]"
         onWheel={(event) => {
-          event.preventDefault();
+          event.stopPropagation();
           moveSelection(event.deltaY > 0 ? 1 : -1);
         }}
         onTouchStart={(event) => {
@@ -211,8 +211,8 @@ export const DateVoteBefore: React.FC<{
             resetSelections();
             setIsPopupOpen(false);
           }}
-          onWheel={(event) => event.preventDefault()}
-          onTouchMove={(event) => event.preventDefault()}
+          onWheel={(event) => event.stopPropagation()}
+          onTouchMove={(event) => event.stopPropagation()}
         >
           <div
             className="w-full max-w-sm rounded-[20px] bg-white p-5 shadow-lg"

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -190,7 +190,7 @@ export const DateVoteBefore: React.FC<{
             {canDeleteOption && option.editable && (
               <button
                 type="button"
-                className="text-[11px] font-semibold text-[#FF3B30]"
+                className="text-[11px] font-semibold text-[#FF3B30] bg-transparent"
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -27,7 +27,18 @@ export const DateVoteBefore: React.FC<{
   onToggleOption: (optionId: string) => void;
   onVote: () => void;
   onAddOption: (label: string) => void;
-}> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+  canDeleteOption?: boolean;
+  onDeleteOption?: (optionId: string) => void;
+}> = ({
+  vote,
+  allowDuplicate,
+  selectedOptionIds,
+  onToggleOption,
+  onVote,
+  onAddOption,
+  canDeleteOption,
+  onDeleteOption,
+}) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [selectedYear, setSelectedYear] = useState("");
   const [selectedMonth, setSelectedMonth] = useState("");
@@ -175,7 +186,20 @@ export const DateVoteBefore: React.FC<{
               onChange={() => onToggleOption(option.id)}
               className="h-4 w-4 text-[#5856D6]"
             />
-            {option.label}
+            <span className="flex-1">{option.label}</span>
+            {canDeleteOption && (
+              <button
+                type="button"
+                className="text-[11px] font-semibold text-[#FF3B30]"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onDeleteOption?.(option.id);
+                }}
+              >
+                삭제
+              </button>
+            )}
           </label>
         ))}
       </div>

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -187,7 +187,7 @@ export const DateVoteBefore: React.FC<{
               className="h-4 w-4 text-[#5856D6]"
             />
             <span className="flex-1">{option.label}</span>
-            {canDeleteOption && (
+            {canDeleteOption && option.editable && (
               <button
                 type="button"
                 className="text-[11px] font-semibold text-[#FF3B30]"

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -76,7 +76,7 @@ export const PlaceVoteBefore: React.FC<{
               className="h-4 w-4 text-[#5856D6]"
             />
             <span className="flex-1">{option.label}</span>
-            {canDeleteOption && (
+            {canDeleteOption && option.editable && (
               <button
                 type="button"
                 className="text-[11px] font-semibold text-[#FF3B30]"

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -79,7 +79,7 @@ export const PlaceVoteBefore: React.FC<{
             {canDeleteOption && option.editable && (
               <button
                 type="button"
-                className="text-[11px] font-semibold text-[#FF3B30]"
+                className="text-[11px] font-semibold text-[#FF3B30] bg-transparent"
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -28,7 +28,18 @@ export const PlaceVoteBefore: React.FC<{
   onToggleOption: (optionId: string) => void;
   onVote: () => void;
   onAddOption: (label: string) => void;
-}> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+  canDeleteOption?: boolean;
+  onDeleteOption?: (optionId: string) => void;
+}> = ({
+  vote,
+  allowDuplicate,
+  selectedOptionIds,
+  onToggleOption,
+  onVote,
+  onAddOption,
+  canDeleteOption,
+  onDeleteOption,
+}) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<string>("");
   const [isAdding, setIsAdding] = useState(false);
@@ -64,7 +75,20 @@ export const PlaceVoteBefore: React.FC<{
               onChange={() => onToggleOption(option.id)}
               className="h-4 w-4 text-[#5856D6]"
             />
-            {option.label}
+            <span className="flex-1">{option.label}</span>
+            {canDeleteOption && (
+              <button
+                type="button"
+                className="text-[11px] font-semibold text-[#FF3B30]"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onDeleteOption?.(option.id);
+                }}
+              >
+                삭제
+              </button>
+            )}
           </label>
         ))}
       </div>

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -65,7 +65,7 @@ export const TextVoteBefore: React.FC<{
             {canDeleteOption && option.editable && (
               <button
                 type="button"
-                className="text-[11px] font-semibold text-[#FF3B30]"
+                className="text-[11px] font-semibold text-[#FF3B30] bg-transparent"
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -27,7 +27,18 @@ export const TextVoteBefore: React.FC<{
   onToggleOption: (optionId: string) => void;
   onVote: () => void;
   onAddOption: (label: string) => void;
-}> = ({ vote, allowDuplicate, selectedOptionIds, onToggleOption, onVote, onAddOption }) => {
+  canDeleteOption?: boolean;
+  onDeleteOption?: (optionId: string) => void;
+}> = ({
+  vote,
+  allowDuplicate,
+  selectedOptionIds,
+  onToggleOption,
+  onVote,
+  onAddOption,
+  canDeleteOption,
+  onDeleteOption,
+}) => {
   const [isAdding, setIsAdding] = useState(false);
   const [newOption, setNewOption] = useState("");
 
@@ -50,7 +61,20 @@ export const TextVoteBefore: React.FC<{
               onChange={() => onToggleOption(option.id)}
               className="h-4 w-4 text-[#5856D6]"
             />
-            {option.label}
+            <span className="flex-1">{option.label}</span>
+            {canDeleteOption && (
+              <button
+                type="button"
+                className="text-[11px] font-semibold text-[#FF3B30]"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onDeleteOption?.(option.id);
+                }}
+              >
+                삭제
+              </button>
+            )}
           </label>
         ))}
       </div>

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -62,7 +62,7 @@ export const TextVoteBefore: React.FC<{
               className="h-4 w-4 text-[#5856D6]"
             />
             <span className="flex-1">{option.label}</span>
-            {canDeleteOption && (
+            {canDeleteOption && option.editable && (
               <button
                 type="button"
                 className="text-[11px] font-semibold text-[#FF3B30]"

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -51,6 +51,7 @@ const mapVoteResponses = (response?: VoteListResponse): Vote[] => {
       label: option.value,
       count: option.voters.length,
       voted: option.isVoted,
+      editable: option.editable,
       memberList: option.voters.map((name) => ({ name })),
     })),
     deadline: vote.deadline ?? undefined,
@@ -65,7 +66,7 @@ const formatVoteDeadline = (deadline?: string | null) => {
 };
 
 const normalizeVoteOption = (option: VoteItemResponse["options"][number]) =>
-  new VoteOptionResponse(String(option.id), option.value, option.isVoted, option.voters);
+  new VoteOptionResponse(String(option.id), option.value, option.isVoted, option.voters, option.editable);
 
 const normalizeVoteItem = (vote: VoteItemResponse) =>
   new VoteItemResponse(
@@ -289,7 +290,7 @@ const PostDetailPage: React.FC = () => {
         if (String(vote.id) !== voteId) return vote;
 
         const resetOptions = vote.options.map(
-          (option) => new VoteOptionResponse(option.id, option.value, false, option.voters),
+          (option) => new VoteOptionResponse(option.id, option.value, false, option.voters, option.editable),
         );
 
         return new VoteItemResponse(

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -138,12 +138,12 @@ const PostDetailPage: React.FC = () => {
         const votes = prev.votes.map((vote) => {
           if (String(vote.id) !== normalizedVote.id) return vote;
 
-          const existingOptions = new Map(vote.options.map((option) => [option.id, option]));
-          const mergedOptions = [...vote.options];
+          const optionMap = new Map<string, VoteOptionResponse>();
+          normalizedVote.options.forEach((option) => optionMap.set(option.id, option));
 
-          normalizedVote.options.forEach((option) => {
-            if (!existingOptions.has(option.id)) {
-              mergedOptions.push(option);
+          vote.options.forEach((existingOption) => {
+            if (!optionMap.has(existingOption.id)) {
+              optionMap.set(existingOption.id, existingOption);
             }
           });
 
@@ -156,7 +156,7 @@ const PostDetailPage: React.FC = () => {
             normalizedVote.type,
             normalizedVote.result,
             normalizedVote.status,
-            mergedOptions,
+            Array.from(optionMap.values()),
           );
         });
 

--- a/src/types/postDetailResponse.ts
+++ b/src/types/postDetailResponse.ts
@@ -16,6 +16,7 @@ export class VoteOptionResponse {
     public value: string,
     public isVoted: boolean,
     public voters: string[],
+    public editable = false,
   ) {}
 }
 

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -3,6 +3,7 @@ export type VoteOption = {
   label: string;
   count: number;
   voted: boolean;
+  editable?: boolean;
   memberList?: { name: string }[];
 };
 


### PR DESCRIPTION
## Summary
- avoid refetching the entire vote list after adding a vote option
- merge newly added options into the cached vote data to prevent full page redraw

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd8b784048324bf746fa62032ef9e)