### PR TITLE
Update participation vote handling on post detail

### DIFF
--- a/src/types/postDetailResponse.ts
+++ b/src/types/postDetailResponse.ts
@@ -37,3 +37,15 @@ export class VoteItemResponse {
 export class VoteListResponse {
   constructor(public votes: VoteItemResponse[]) {}
 }
+
+export type ParticipationVoteResult = {
+  id: string;
+  isActive: boolean;
+  hasVoted: boolean;
+  yesCount: number;
+  noCount: number;
+  participantCount: number;
+  yesMembers: { name: string }[];
+  noMembers: { name: string }[];
+  choice: "yes" | "no" | null;
+};


### PR DESCRIPTION
## Summary
- add participation vote fetch, vote, terminate, and delete API integrations for post detail
- wire participation UI actions to the new APIs and expose management buttons
- adjust closed participation view to avoid duplicate participant count display

## Testing
- npm run lint *(fails due to pre-existing lint errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950a77a797c8324b0cdde05c0aa8544)