### PR TITLE
Connect participation vote actions to APIs

### DIFF
--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -41,6 +41,7 @@ type ParticipationVotePayload = {
   id?: string | number;
   endDate?: string;
   itemList?: ParticipationVoteItemPayload[];
+  participants?: (string | number)[];
   active?: boolean;
   voted?: boolean;
 };
@@ -207,12 +208,20 @@ export const fetchParticipationVote = async (postId: string): Promise<Participat
   const yesItem = options.find((item) => item.name === "참여");
   const noItem = options.find((item) => item.name === "불참");
 
+  const participants = Array.isArray(payload.participants)
+    ? payload.participants.map((member) => ({ name: String(member) }))
+    : [];
+
   const yesMembers = Array.isArray(yesItem?.memberList)
     ? yesItem?.memberList.map((member) => ({ name: String(member) }))
-    : [];
+    : participants;
   const noMembers = Array.isArray(noItem?.memberList)
     ? noItem?.memberList.map((member) => ({ name: String(member) }))
     : [];
+
+  const participantCount = participants.length
+    ? participants.length
+    : yesMembers.length + noMembers.length;
 
   let votedChoice: ParticipationChoice = null;
   if (yesItem?.vote) votedChoice = "yes";
@@ -225,7 +234,7 @@ export const fetchParticipationVote = async (postId: string): Promise<Participat
       hasVoted: Boolean(payload.voted ?? false),
       yesCount: yesMembers.length,
       noCount: noMembers.length,
-      participantCount: yesMembers.length,
+      participantCount,
       yesMembers,
       noMembers,
       yesOptionId: yesItem?.id != null ? String(yesItem.id) : undefined,

--- a/src/api/postDetail.ts
+++ b/src/api/postDetail.ts
@@ -57,6 +57,8 @@ export type ParticipationVoteResponse = {
     participantCount: number;
     yesMembers: { name: string }[];
     noMembers: { name: string }[];
+    yesOptionId?: string;
+    noOptionId?: string;
   };
   votedChoice: ParticipationChoice;
 };
@@ -226,10 +228,36 @@ export const fetchParticipationVote = async (postId: string): Promise<Participat
       participantCount: yesMembers.length,
       yesMembers,
       noMembers,
+      yesOptionId: yesItem?.id != null ? String(yesItem.id) : undefined,
+      noOptionId: noItem?.id != null ? String(noItem.id) : undefined,
     },
     votedChoice,
   };
 };
+
+export const submitParticipationVote = async ({
+  postId,
+  participateVoteItemId,
+}: {
+  postId: string;
+  participateVoteItemId: string;
+}) =>
+  server.post("/participate/vote", {
+    data: {
+      postId,
+      participateVoteItemId,
+    },
+  });
+
+export const terminateParticipationVote = async ({ postId }: { postId: string }) =>
+  server.post("/participate/terminate", {
+    data: { postId },
+  });
+
+export const deleteParticipationVote = async ({ postId }: { postId: string }) =>
+  server.delete("/participate", {
+    params: { postId },
+  });
 
 export const addVoteOption = async ({
   voteId,

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -470,15 +470,6 @@ const PostDetailPage: React.FC = () => {
   const handleEndParticipationVote = () => {
     if (!participationVote || participationVote.activeYn === "N") return;
     terminateParticipationVoteMutation.mutate();
-    setParticipationVote((prev) =>
-      prev
-        ? {
-            ...prev,
-            activeYn: "N",
-            participantCount: prev.yesCount,
-          }
-        : prev,
-    );
   };
 
   const handleDeleteParticipationVote = () => {
@@ -492,31 +483,6 @@ const PostDetailPage: React.FC = () => {
       participationChoice === "yes" ? participationVote.yesOptionId : participationVote.noOptionId;
 
     if (!participationVoteId) return;
-    setParticipationVote((prev) =>
-      prev
-        ? {
-            ...prev,
-            hasVoted: true,
-            yesCount:
-              participationChoice === "yes"
-                ? prev.yesCount + 1 - (participationVotedChoice === "yes" ? 1 : 0)
-                : prev.yesCount - (participationVotedChoice === "yes" ? 1 : 0),
-            noCount:
-              participationChoice === "no"
-                ? prev.noCount + 1 - (participationVotedChoice === "no" ? 1 : 0)
-                : prev.noCount - (participationVotedChoice === "no" ? 1 : 0),
-            yesMembers:
-              participationChoice === "yes"
-                ? [{ name: "나" }, ...prev.yesMembers.filter((member) => member.name !== "나")]
-                : prev.yesMembers.filter((member) => member.name !== "나"),
-            noMembers:
-              participationChoice === "no"
-                ? [{ name: "나" }, ...prev.noMembers.filter((member) => member.name !== "나")]
-                : prev.noMembers.filter((member) => member.name !== "나"),
-          }
-        : prev,
-    );
-    setParticipationVotedChoice(participationChoice);
     participationVoteMutation.mutate(participationChoice);
   };
 


### PR DESCRIPTION
## Summary
- add API helpers for participation vote termination, deletion, and voting
- connect participation vote UI actions to backend endpoints and add a delete control on the detail page
- adjust inactive participation count text to avoid duplicate display

## Testing
- npm run lint *(fails: existing lint warnings and errors in unrelated files)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950aa95627c832483cf8638fd7df11b)