### PR TITLE
Show detailed results for closed votes

### DIFF
--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -2,24 +2,6 @@ import React, { useEffect, useState } from "react";
 import type { Vote } from "../../types/vote";
 import VotedMemberList from "../popUp/VotedMemberList";
 
-const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
-  <div className="mt-3 flex flex-col gap-2">
-    {options.map((option) => (
-      <div
-        key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
-          highlightVoted && option.voted
-            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
-            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-        }`}
-      >
-        <span>{option.label}</span>
-        <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
-      </div>
-    ))}
-  </div>
-);
-
 export const DateVoteBefore: React.FC<{
   vote: Vote;
   allowDuplicate: boolean;
@@ -329,7 +311,37 @@ export const DateVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
 };
 
 export const DateVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
-  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-    <OptionResults options={vote.options} highlightVoted />
-  </div>
+  <DateVoteResult vote={vote} />
 );
+
+const DateVoteResult: React.FC<{ vote: Vote }> = ({ vote }) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+  const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+      <div className="mt-2 flex flex-col gap-2">
+        {vote.options.map((option) => (
+          <div
+            key={option.id}
+            className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
+              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+            }`}
+          >
+            <span>{option.label}</span>
+            <button
+              type="button"
+              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
+              onClick={() => setSelectedOptionId(option.id)}
+            >
+              {option.count}명
+            </button>
+          </div>
+        ))}
+      </div>
+      {selectedOption && (
+        <VotedMemberList selectedItem={{ memberList: selectedOption.memberList ?? [] }} closePopup={() => setSelectedOptionId(null)} />
+      )}
+    </div>
+  );
+};

--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -315,12 +315,15 @@ export const DateVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
 );
 
 const DateVoteResult: React.FC<{ vote: Vote }> = ({ vote }) => {
+  if(vote.options.length === 0) {
+      return "항목이 없습니다.";
+  }
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
   const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
 
   return (
-    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-      <div className="mt-2 flex flex-col gap-2">
+    <div className="rounded-[20px]">
+      <div className="flex flex-col gap-2">
         {vote.options.map((option) => (
           <div
             key={option.id}

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -3,24 +3,6 @@ import type { Vote } from "../../types/vote";
 import VotedMemberList from "../popUp/VotedMemberList";
 import SearchPopup from "../popUp/PlaceSearch";
 
-const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
-  <div className="mt-3 flex flex-col gap-2">
-    {options.map((option) => (
-      <div
-        key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
-          highlightVoted && option.voted
-            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
-            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-        }`}
-      >
-        <span>{option.label}</span>
-        <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
-      </div>
-    ))}
-  </div>
-);
-
 export const PlaceVoteBefore: React.FC<{
   vote: Vote;
   allowDuplicate: boolean;
@@ -186,7 +168,37 @@ export const PlaceVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({
 };
 
 export const PlaceVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
-  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-    <OptionResults options={vote.options} highlightVoted />
-  </div>
+  <PlaceVoteResult vote={vote} />
 );
+
+const PlaceVoteResult: React.FC<{ vote: Vote }> = ({ vote }) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+  const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+      <div className="mt-2 flex flex-col gap-2">
+        {vote.options.map((option) => (
+          <div
+            key={option.id}
+            className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
+              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+            }`}
+          >
+            <span>{option.label}</span>
+            <button
+              type="button"
+              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
+              onClick={() => setSelectedOptionId(option.id)}
+            >
+              {option.count}명
+            </button>
+          </div>
+        ))}
+      </div>
+      {selectedOption && (
+        <VotedMemberList selectedItem={{ memberList: selectedOption.memberList ?? [] }} closePopup={() => setSelectedOptionId(null)} />
+      )}
+    </div>
+  );
+};

--- a/src/components/vote/PlaceVote.tsx
+++ b/src/components/vote/PlaceVote.tsx
@@ -172,12 +172,16 @@ export const PlaceVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
 );
 
 const PlaceVoteResult: React.FC<{ vote: Vote }> = ({ vote }) => {
+  if(vote.options.length === 0) {
+      return "항목이 없습니다.";
+  }
+
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
   const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
 
   return (
-    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-      <div className="mt-2 flex flex-col gap-2">
+    <div className="rounded-[20px]">
+      <div className="flex flex-col gap-2">
         {vote.options.map((option) => (
           <div
             key={option.id}

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -2,24 +2,6 @@ import React, { useState } from "react";
 import type { Vote } from "../../types/vote";
 import VotedMemberList from "../popUp/VotedMemberList";
 
-const OptionResults: React.FC<{ options: Vote["options"]; highlightVoted?: boolean }> = ({ options, highlightVoted }) => (
-  <div className="mt-3 flex flex-col gap-2">
-    {options.map((option) => (
-      <div
-        key={option.id}
-        className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
-          highlightVoted && option.voted
-            ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]"
-            : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
-        }`}
-      >
-        <span>{option.label}</span>
-        <span className="text-[11px] font-semibold text-[#8E8E93]">{option.count}표</span>
-      </div>
-    ))}
-  </div>
-);
-
 export const TextVoteBefore: React.FC<{
   vote: Vote;
   allowDuplicate: boolean;
@@ -171,7 +153,37 @@ export const TextVoteAfter: React.FC<{ vote: Vote; onRevote: () => void }> = ({ 
 };
 
 export const TextVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
-  <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-    <OptionResults options={vote.options} highlightVoted />
-  </div>
+  <TextVoteResult vote={vote} />
 );
+
+const TextVoteResult: React.FC<{ vote: Vote }> = ({ vote }) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
+  const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
+
+  return (
+    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
+      <div className="mt-2 flex flex-col gap-2">
+        {vote.options.map((option) => (
+          <div
+            key={option.id}
+            className={`flex items-center justify-between rounded-xl border px-4 py-2 text-xs font-medium ${
+              option.voted ? "border-[#5856D6] bg-[#EAE9FF] text-[#1C1C1E]" : "border-[#E5E5EA] bg-white text-[#1C1C1E]"
+            }`}
+          >
+            <span>{option.label}</span>
+            <button
+              type="button"
+              className="bg-transparent text-[11px] font-semibold text-[#5856D6]"
+              onClick={() => setSelectedOptionId(option.id)}
+            >
+              {option.count}명
+            </button>
+          </div>
+        ))}
+      </div>
+      {selectedOption && (
+        <VotedMemberList selectedItem={{ memberList: selectedOption.memberList ?? [] }} closePopup={() => setSelectedOptionId(null)} />
+      )}
+    </div>
+  );
+};

--- a/src/components/vote/TextVote.tsx
+++ b/src/components/vote/TextVote.tsx
@@ -157,12 +157,15 @@ export const TextVoteComplete: React.FC<{ vote: Vote }> = ({ vote }) => (
 );
 
 const TextVoteResult: React.FC<{ vote: Vote }> = ({ vote }) => {
+  if(vote.options.length === 0) {
+      return "항목이 없습니다.";
+  }
+
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
   const selectedOption = vote.options.find((option) => option.id === selectedOptionId);
-
   return (
-    <div className="mt-4 rounded-[20px] border border-[#E5E5EA] bg-[#F9F9FB] p-4">
-      <div className="mt-2 flex flex-col gap-2">
+    <div className="rounded-[20px]">
+      <div className="flex flex-col gap-2">
         {vote.options.map((option) => (
           <div
             key={option.id}

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -503,11 +503,29 @@ const PostDetailPage: React.FC = () => {
   }, [participationVote]);
 
   const renderClosedVote = (vote: Vote) => {
-    return (
-      <div className="mt-3 rounded-[16px] bg-[#F9F9FB] px-4 py-3 text-sm font-semibold text-[#5856D6]">
-        {vote.result ? vote.result : "선택된 항목이 없습니다."}
-      </div>
-    );
+      if (vote.type === "date") {
+        return (
+          <div className="rounded-[16px] px-4 py-3 text-sm font-semibold text-[#5856D6]">
+            <DateVoteComplete vote={vote} />
+          </div>
+        );
+      }
+
+      if (vote.type === "place") {
+        return (
+          <div className="rounded-[16px] px-4 py-3 text-sm font-semibold text-[#5856D6]">
+            <PlaceVoteComplete vote={vote} />
+          </div>
+        );
+      }
+
+      if (vote.type === "text") {
+        return (
+          <div className="rounded-[16px] px-4 py-3 text-sm font-semibold text-[#5856D6]">
+            <TextVoteComplete vote={vote} />
+          </div>
+        );
+      }
   };
 
   const renderVoteState = (vote: Vote) => {


### PR DESCRIPTION
### Motivation
- Closed votes previously showed only aggregate results but should display the same detailed view as the "voted" state, including which option the user chose and the per-option voter lists and counts.

### Description
- Updated date/place/text vote components to render a detailed results view for closed votes by replacing the old compact `OptionResults` usage with new result components (`DateVoteResult`, `PlaceVoteResult`, `TextVoteResult`).
- Each new result component lists options with the same voted-item highlighting as the "after" state and shows the option vote count as a button that opens `VotedMemberList` for the per-option voter list.
- Removed the duplicated `OptionResults` rendering for the complete state and consolidated behavior across `src/components/vote/DateVote.tsx`, `src/components/vote/PlaceVote.tsx`, and `src/components/vote/TextVote.tsx`.

### Testing
- Started the dev server with `npm run dev` and the Vite server reported ready and reachable at `http://localhost:4173/`, which succeeded. 
- Ran a Playwright script that navigated to `/post/1` and captured a screenshot (`artifacts/vote-complete.png`) to verify the closed vote UI, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b457ac9208324ad8a99dda00da304)