### PR TITLE
Left-indent vote titles; use calendar input and speed up time picker in DateVote

### DIFF
--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -647,7 +647,7 @@ const PostDetailPage: React.FC = () => {
                     </div>
                   )}
                   <div className="mt-2 flex items-start justify-between">
-                    <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
+                    <h3 className="pl-2 text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
                     {!isClosed && (
                       <div className="flex flex-col items-end gap-1 text-[11px] font-semibold text-[#8E8E93]">
                         {vote.deadline && <span>마감일 : {formatVoteDeadline(vote.deadline)}</span>}


### PR DESCRIPTION
### Motivation
- Improve visual alignment of vote cards by adding a left indent to vote titles.
- Make adding date options easier by replacing the custom year/month/day picker with a native calendar input.
- Improve UX for time selection by increasing the scroll step so time columns scroll faster.

### Description
- Adjusted the PostDetail vote title to include left padding in `src/pages/PostDetail.tsx` by adding `pl-2` to the title element.
- Reworked date option entry in `src/components/vote/DateVote.tsx` by replacing separate year/month/day pickers with a single `<input type="date">` and consolidating state into `selectedDate`.
- Removed manual day validation and string assembly for date parts and now build option labels using `selectedDate` plus calculated 24-hour time.
- Updated the picker helper `renderPickerColumn` to accept a `scrollStep` parameter and used `scrollStep: 2` for time-related columns to speed up wheel/touch scrolling.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready (local and network URLs), which succeeded.
- Ran a Playwright script that opened `http://127.0.0.1:4173/post/1` and captured a screenshot; the script completed and produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6088ecb48324acf5e020e6af1543)