### PR TITLE
Smooth and faster time scrolling in DateVote; refactor pickers and use calendar input

### DIFF
--- a/src/components/vote/DateVote.tsx
+++ b/src/components/vote/DateVote.tsx
@@ -1,6 +1,102 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { Vote } from "../../types/vote";
 import VotedMemberList from "../popUp/VotedMemberList";
+
+type PickerColumnProps<T extends string> = {
+  items: T[];
+  selected: T;
+  onSelect: (value: T) => void;
+  allowWrap?: boolean;
+  scrollStep?: number;
+};
+
+const PickerColumn = <T extends string>({
+  items,
+  selected,
+  onSelect,
+  allowWrap = true,
+  scrollStep = 1,
+}: PickerColumnProps<T>) => {
+  const selectedIndex = Math.max(0, items.indexOf(selected === "" ? items[0] : selected));
+  const getNeighbor = (direction: 1 | -1) => {
+    if (allowWrap) {
+      return items[(selectedIndex + direction + items.length) % items.length];
+    }
+    const nextIndex = selectedIndex + direction;
+    if (nextIndex < 0 || nextIndex >= items.length) return "" as T;
+    return items[nextIndex];
+  };
+
+  const current = items[selectedIndex];
+  const prev = getNeighbor(-1);
+  const next = getNeighbor(1);
+
+  const moveSelection = (direction: 1 | -1, step = 1) => {
+    let newIndex = selectedIndex + direction * step;
+    if (allowWrap) {
+      newIndex = (newIndex + items.length) % items.length;
+    } else {
+      newIndex = Math.min(items.length - 1, Math.max(0, newIndex));
+    }
+    onSelect(items[newIndex]);
+  };
+
+  const touchStartY = useRef<number | null>(null);
+  const wheelDeltaRef = useRef(0);
+  const wheelFrameRef = useRef<number | null>(null);
+  const baseWheelStep = 24;
+
+  return (
+    <div
+      className="flex h-40 w-16 flex-col items-center justify-center text-center text-xs font-semibold text-[#5856D6]"
+      onWheel={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        wheelDeltaRef.current += event.deltaY;
+        if (wheelFrameRef.current !== null) return;
+        wheelFrameRef.current = window.requestAnimationFrame(() => {
+          const delta = wheelDeltaRef.current;
+          const direction = delta > 0 ? 1 : -1;
+          const steps = Math.max(1, Math.round(Math.abs(delta) / baseWheelStep));
+          moveSelection(direction, steps * scrollStep);
+          wheelDeltaRef.current = 0;
+          wheelFrameRef.current = null;
+        });
+      }}
+      onTouchStart={(event) => {
+        touchStartY.current = event.touches[0].clientY;
+      }}
+      onTouchEnd={(event) => {
+        if (touchStartY.current === null) return;
+        const deltaY = event.changedTouches[0].clientY - touchStartY.current;
+        if (Math.abs(deltaY) > 10) {
+          moveSelection(deltaY > 0 ? -1 : 1, scrollStep);
+        }
+        touchStartY.current = null;
+      }}
+    >
+      <button
+        type="button"
+        className="w-full bg-transparent py-2 text-[#5856D6]"
+        onClick={() => moveSelection(-1)}
+      >
+        <span className="block h-5 leading-5">{prev || ""}</span>
+      </button>
+      <div className="h-px w-full bg-[#5856D6]" />
+      <div className="w-full py-2 text-sm font-bold text-[#5856D6]">
+        <span className="block h-6 leading-6">{current}</span>
+      </div>
+      <div className="h-px w-full bg-[#5856D6]" />
+      <button
+        type="button"
+        className="w-full bg-transparent py-2 text-[#5856D6]"
+        onClick={() => moveSelection(1)}
+      >
+        <span className="block h-5 leading-5">{next || ""}</span>
+      </button>
+    </div>
+  );
+};
 
 export const DateVoteBefore: React.FC<{
   vote: Vote;
@@ -22,9 +118,7 @@ export const DateVoteBefore: React.FC<{
   onDeleteOption,
 }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [selectedYear, setSelectedYear] = useState("");
-  const [selectedMonth, setSelectedMonth] = useState("");
-  const [selectedDay, setSelectedDay] = useState("");
+  const [selectedDate, setSelectedDate] = useState("");
   const [selectedPeriod, setSelectedPeriod] = useState<"오전" | "오후">("오전");
   const [selectedHour, setSelectedHour] = useState("");
   const [selectedMinute, setSelectedMinute] = useState("");
@@ -42,9 +136,7 @@ export const DateVoteBefore: React.FC<{
   }, [isPopupOpen]);
 
   const resetSelections = () => {
-    setSelectedYear("");
-    setSelectedMonth("");
-    setSelectedDay("");
+    setSelectedDate("");
     setSelectedPeriod("오전");
     setSelectedHour("");
     setSelectedMinute("");
@@ -52,109 +144,21 @@ export const DateVoteBefore: React.FC<{
   };
 
   const handleConfirm = () => {
-    if (!selectedYear || !selectedMonth || !selectedDay || !selectedHour || !selectedMinute) {
+    if (!selectedDate || !selectedHour || !selectedMinute) {
       setErrorMessage("날짜와 시간을 모두 선택해주세요.");
       return;
     }
 
-    const yearNum = Number(selectedYear);
-    const monthNum = Number(selectedMonth);
-    const dayNum = Number(selectedDay);
-    const maxDay = new Date(yearNum, monthNum, 0).getDate();
-
-    if (dayNum > maxDay) {
-      setErrorMessage("해당 월에 없는 날짜입니다. 다시 선택해주세요.");
-      return;
-    }
-
-    const month = selectedMonth.padStart(2, "0");
-    const day = selectedDay.padStart(2, "0");
     const hourNumber = Number(selectedHour);
     const hour24 = selectedPeriod === "오후" ? ((hourNumber % 12) + 12).toString().padStart(2, "0") : (hourNumber % 12).toString().padStart(2, "0");
-    onAddOption(`${selectedYear}-${month}-${day} ${hour24}:${selectedMinute}`);
+    onAddOption(`${selectedDate} ${hour24}:${selectedMinute}`);
     resetSelections();
     setIsPopupOpen(false);
   };
 
-  const today = new Date();
-  const yearOptions = [String(today.getFullYear()), String(today.getFullYear() + 1)];
-  const monthOptions = Array.from({ length: 12 }, (_, index) => String(index + 1));
-  const dayOptions = Array.from({ length: 31 }, (_, index) => String(index + 1));
+  const todayDate = new Date().toISOString().split("T")[0];
   const hourOptions = Array.from({ length: 12 }, (_, index) => String(index + 1).padStart(2, "0"));
   const minuteOptions = Array.from({ length: 12 }, (_, index) => String(index * 5).padStart(2, "0"));
-  const renderPickerColumn = <T extends string>(
-    items: T[],
-    selected: T,
-    onSelect: (value: T) => void,
-    { allowWrap = true }: { allowWrap?: boolean } = {},
-  ) => {
-    const selectedIndex = Math.max(0, items.indexOf(selected === "" ? items[0] : selected));
-    const getNeighbor = (direction: 1 | -1) => {
-      if (allowWrap) {
-        return items[(selectedIndex + direction + items.length) % items.length];
-      }
-      const nextIndex = selectedIndex + direction;
-      if (nextIndex < 0 || nextIndex >= items.length) return "" as T;
-      return items[nextIndex];
-    };
-
-    const current = items[selectedIndex];
-    const prev = getNeighbor(-1);
-    const next = getNeighbor(1);
-
-    const moveSelection = (direction: 1 | -1) => {
-      let newIndex = selectedIndex + direction;
-      if (allowWrap) {
-        newIndex = (newIndex + items.length) % items.length;
-      } else {
-        newIndex = Math.min(items.length - 1, Math.max(0, newIndex));
-      }
-      onSelect(items[newIndex]);
-    };
-
-    let touchStartY: number | null = null;
-
-    return (
-      <div
-        className="flex h-40 w-16 flex-col items-center justify-center text-center text-xs font-semibold text-[#5856D6]"
-        onWheel={(event) => {
-          event.stopPropagation();
-          moveSelection(event.deltaY > 0 ? 1 : -1);
-        }}
-        onTouchStart={(event) => {
-          touchStartY = event.touches[0].clientY;
-        }}
-        onTouchEnd={(event) => {
-          if (touchStartY === null) return;
-          const deltaY = event.changedTouches[0].clientY - touchStartY;
-          if (Math.abs(deltaY) > 10) {
-            moveSelection(deltaY > 0 ? -1 : 1);
-          }
-          touchStartY = null;
-        }}
-      >
-        <button
-          type="button"
-          className="w-full bg-transparent py-2 text-[#5856D6]"
-          onClick={() => moveSelection(-1)}
-        >
-          <span className="block h-5 leading-5">{prev || ""}</span>
-        </button>
-        <div className="h-px w-full bg-[#5856D6]" />
-        <div className="w-full py-2 text-sm font-bold text-[#5856D6]">
-          <span className="block h-6 leading-6">{current}</span>
-        </div>
-        <div className="h-px w-full bg-[#5856D6]" />
-        <button
-          type="button"
-          className="w-full bg-transparent py-2 text-[#5856D6]"
-          onClick={() => moveSelection(1)}
-        >
-          <span className="block h-5 leading-5">{next || ""}</span>
-        </button>
-      </div>
-    );
-  };
 
   return (
     <div className="mt-4 rounded-[20px] border border-dashed border-[#C7C7CC] bg-[#F9F9FB] p-4">
@@ -189,9 +193,7 @@ export const DateVoteBefore: React.FC<{
         <button
           type="button"
           onClick={() => {
-            setSelectedYear(yearOptions[0]);
-            setSelectedMonth(monthOptions[0]);
-            setSelectedDay(dayOptions[0]);
+            setSelectedDate(todayDate);
             setSelectedPeriod("오전");
             setSelectedHour(hourOptions[0]);
             setSelectedMinute(minuteOptions[0]);
@@ -227,18 +229,35 @@ export const DateVoteBefore: React.FC<{
             <div className="space-y-4">
               <div className="space-y-2">
                 <span className="text-[11px] font-semibold text-[#8E8E93]">날짜</span>
-                <div className="flex items-center justify-center gap-3">
-                  {renderPickerColumn(yearOptions, selectedYear || yearOptions[0], setSelectedYear, { allowWrap: false })}
-                  {renderPickerColumn(monthOptions, selectedMonth || monthOptions[0], setSelectedMonth)}
-                  {renderPickerColumn(dayOptions, selectedDay || dayOptions[0], setSelectedDay)}
-                </div>
+                <input
+                  type="date"
+                  value={selectedDate}
+                  onChange={(event) => setSelectedDate(event.target.value)}
+                  className="w-full rounded-[12px] border border-[#E5E5EA] px-3 py-2 text-xs font-semibold text-[#1C1C1E]"
+                />
               </div>
               <div className="space-y-2">
                 <span className="text-[11px] font-semibold text-[#8E8E93]">시간</span>
                 <div className="flex items-center justify-center gap-3">
-                  {renderPickerColumn(["오전", "오후"] as const, selectedPeriod, setSelectedPeriod, { allowWrap: false })}
-                  {renderPickerColumn(hourOptions, selectedHour || hourOptions[0], setSelectedHour)}
-                  {renderPickerColumn(minuteOptions, selectedMinute || minuteOptions[0], setSelectedMinute)}
+                  <PickerColumn
+                    items={["오전", "오후"] as const}
+                    selected={selectedPeriod}
+                    onSelect={setSelectedPeriod}
+                    allowWrap={false}
+                    scrollStep={2}
+                  />
+                  <PickerColumn
+                    items={hourOptions}
+                    selected={selectedHour || hourOptions[0]}
+                    onSelect={setSelectedHour}
+                    scrollStep={2}
+                  />
+                  <PickerColumn
+                    items={minuteOptions}
+                    selected={selectedMinute || minuteOptions[0]}
+                    onSelect={setSelectedMinute}
+                    scrollStep={2}
+                  />
                 </div>
               </div>
             </div>

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -647,7 +647,7 @@ const PostDetailPage: React.FC = () => {
                     </div>
                   )}
                   <div className="mt-2 flex items-start justify-between">
-                    <h3 className="text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
+                    <h3 className="pl-2 text-base font-semibold text-[#1C1C1E]">{vote.title}</h3>
                     {!isClosed && (
                       <div className="flex flex-col items-end gap-1 text-[11px] font-semibold text-[#8E8E93]">
                         {vote.deadline && <span>마감일 : {formatVoteDeadline(vote.deadline)}</span>}


### PR DESCRIPTION
### Motivation
- Make time selection faster and smoother in the date vote UI by improving wheel/touch scrolling behavior. 
- Reduce duplicated picker code by consolidating the picker column logic into a reusable component. 
- Simplify date entry by replacing separate year/month/day pickers with a native calendar input. 
- Align vote titles visually by adding a small left indent.

### Description
- Introduced a generic `PickerColumn` component with props `items`, `selected`, `onSelect`, `allowWrap`, and `scrollStep` and replaced the inline picker rendering with this component in `src/components/vote/DateVote.tsx`.
- Implemented accumulated wheel delta handling using `useRef` and `requestAnimationFrame` plus a `baseWheelStep` and `scrollStep` multiplier so each wheel gesture can move multiple steps for faster scrolling, and preserved touch swipe handling for mobile.
- Replaced year/month/day state and three separate pickers with a single `input type="date"` using `selectedDate`, updated `resetSelections` and `handleConfirm` to build option labels from `selectedDate` and 24-hour conversion logic.
- Added `useRef` import and updated event handlers to `preventDefault`/`stopPropagation` where appropriate to avoid unwanted propagation during wheel/touch interactions.
- Restored a small visual tweak in `src/pages/PostDetail.tsx` by adding `pl-2` to the vote title element for left indentation.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6088ecb48324acf5e020e6af1543)