### PR TITLE
Add Q&A pages, types, routes and tweak Q&A list badge display

### DIFF
--- a/src/pages/PostList.tsx
+++ b/src/pages/PostList.tsx
@@ -4,13 +4,30 @@ import { server } from "@/utils/axios";
 import FooterNav from "../components/FooterNav";
 import { Post } from "@/types/Post";
 
-const TYPE_ORDER = ["회식", "여행", "투표", "공지"];
+const TYPE_ORDER = ["회식", "여행", "투표", "공지", "Q&A"];
 
 const PostList: React.FC = () => {
   const [postList, setPostList] = useState<Post[]>([]);
   const [selectedType, setSelectedType] = useState<string>(TYPE_ORDER[0]);
   const navigate = useNavigate();
   const filteredPosts = postList;
+  const isQnaTab = selectedType === "Q&A";
+
+  const getAnswerStatus = (post: Post) => {
+    if (post.answerStatus) {
+      return post.answerStatus;
+    }
+
+    if (post.answered !== undefined && post.answered !== null) {
+      return post.answered ? "답변 완료" : "답변 없음";
+    }
+
+    if (post.answerYn) {
+      return post.answerYn === "Y" ? "답변 완료" : "답변 없음";
+    }
+
+    return "답변 없음";
+  };
 
   useEffect(() => {
     const fetchMeetList = async () => {
@@ -70,19 +87,33 @@ const PostList: React.FC = () => {
 
           {filteredPosts.length > 0 ? (
             <ul className="flex flex-col gap-4">
-              {filteredPosts.map((post) => (
-                <li key={post.id}>
-                  <Link
-                    to={`/post/${post.id}`}
-                    className="group flex w-full items-center justify-between gap-4 rounded-[22px] bg-white px-5 py-4 shadow-[0_8px_24px_rgba(26,26,26,0.08)] transition-all duration-200 hover:shadow-[0_12px_30px_rgba(26,26,26,0.12)]"
-                  >
-                    <div className="flex items-start gap-4">
-                      <div className="flex flex-col gap-1">
-                        <div className="flex items-center gap-2">
-                          <span className="rounded-full bg-[#E1F0FF] px-[8px] py-[2px] text-[11px] font-semibold text-[#1E3A8A]">
-                            {post.type}
-                          </span>
-                        </div>
+              {filteredPosts.map((post) => {
+                const answerStatus = getAnswerStatus(post);
+
+                return (
+                  <li key={post.id}>
+                    <Link
+                      to={isQnaTab ? `/post/question/${post.id}` : `/post/${post.id}`}
+                      className="group flex w-full items-center justify-between gap-4 rounded-[22px] bg-white px-5 py-4 shadow-[0_8px_24px_rgba(26,26,26,0.08)] transition-all duration-200 hover:shadow-[0_12px_30px_rgba(26,26,26,0.12)]"
+                    >
+                      <div className="flex items-start gap-4">
+                        <div className="flex flex-col gap-1">
+                          <div className="flex items-center gap-2">
+                            <span className="rounded-full bg-[#E1F0FF] px-[8px] py-[2px] text-[11px] font-semibold text-[#1E3A8A]">
+                              {isQnaTab ? post.type ?? "Q&A" : post.type}
+                            </span>
+                            {isQnaTab && (
+                              <span
+                                className={`rounded-full px-[8px] py-[2px] text-[11px] font-semibold ${
+                                  answerStatus === "답변 완료"
+                                    ? "bg-[#E8F5E9] text-[#2E7D32]"
+                                    : "bg-[#FFF8E1] text-[#FF8F00]"
+                                }`}
+                              >
+                                {answerStatus}
+                              </span>
+                            )}
+                          </div>
                         <div className="flex items-center gap-2">
                           <h3 className="text-[15px] font-semibold text-[#1C1C1E] group-hover:text-[#5856D6]">
                             {post.title}
@@ -91,9 +122,10 @@ const PostList: React.FC = () => {
                       </div>
                     </div>
                     <i className="fa-solid fa-chevron-right text-[18px] text-[#AEAEB2] transition-colors group-hover:text-[#5856D6]"></i>
-                  </Link>
-                </li>
-              ))}
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
           ) : (
             <div className="flex flex-col items-center justify-center rounded-[22px] bg-white px-6 py-10 text-center text-[#8E8E93] shadow-inner">
@@ -106,6 +138,18 @@ const PostList: React.FC = () => {
           )}
         </section>
       </main>
+
+      {isQnaTab && (
+        <div className="fixed bottom-20 left-0 right-0 z-20 flex justify-center px-6">
+          <button
+            type="button"
+            onClick={() => navigate("/post/create/question")}
+            className="w-full max-w-md rounded-full bg-[#5856D6] px-6 py-4 text-[15px] font-semibold text-white shadow-[0_12px_30px_rgba(88,86,214,0.35)] transition hover:bg-[#4B49C6]"
+          >
+            글 작성하기
+          </button>
+        </div>
+      )}
 
       <FooterNav />
     </div>

--- a/src/pages/QnaCreate.tsx
+++ b/src/pages/QnaCreate.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { server } from "@/utils/axios";
+import FooterNav from "../components/FooterNav";
+
+const QnaCreate: React.FC = () => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<{ title?: string; content?: string }>({});
+
+  const validate = () => {
+    const nextErrors: { title?: string; content?: string } = {};
+
+    if (!title.trim()) {
+      nextErrors.title = "제목을 입력해 주세요.";
+    }
+
+    if (content.trim().length < 10) {
+      nextErrors.content = "내용은 10글자 이상 입력해 주세요.";
+    }
+
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!validate()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    server
+      .post("/post/create/question", {
+        data: { title: title.trim(), content: content.trim() },
+      })
+      .then(() => {
+        alert("Q&A가 등록되었습니다.");
+        navigate("/post/list");
+      })
+      .catch(() => {
+        alert("Q&A 등록에 실패했습니다.");
+      })
+      .finally(() => {
+        setIsSubmitting(false);
+      });
+  };
+
+  return (
+    <div className="min-h-screen w-full bg-[#F2F2F7]" style={{ paddingBottom: "80px" }}>
+      <main className="mx-auto flex w-full max-w-screen-sm flex-col gap-6 px-4 pb-10 pt-8 sm:max-w-screen-md sm:px-6 lg:max-w-4xl">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-bold text-[#1C1C1E] sm:text-3xl">Q&A 작성하기</h1>
+          <p className="text-[13px] text-[#8E8E93] sm:text-[14px]">
+            궁금한 내용을 입력하면 답변을 받을 수 있어요.
+          </p>
+        </header>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="rounded-[18px] bg-white p-5 shadow-sm sm:p-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-left text-lg font-semibold text-[#1C1C1E] sm:text-xl">
+                질문 내용
+              </h2>
+              <span className="text-[12px] font-medium text-[#8E8E93]">필수</span>
+            </div>
+
+            <div className="mt-4 space-y-4 text-left">
+              <div className="space-y-2">
+                <label className="text-xs text-[#8E8E93] sm:text-sm">제목</label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  className={`w-full rounded-xl border px-4 py-3 text-base font-semibold focus:outline-none sm:text-lg ${
+                    errors.title
+                      ? "border-[#FF6B6B] bg-[#FFF5F5]"
+                      : "border-[#E5E5EA] bg-[#F9F9FB] focus:border-[#5856D6]"
+                  }`}
+                  placeholder="질문 제목을 입력하세요"
+                />
+                {errors.title && <p className="text-[12px] text-[#FF6B6B]">{errors.title}</p>}
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-xs text-[#8E8E93] sm:text-sm">내용</label>
+                <textarea
+                  value={content}
+                  onChange={(e) => setContent(e.target.value)}
+                  rows={6}
+                  className={`w-full resize-none rounded-xl border px-4 py-3 text-sm font-medium focus:outline-none sm:text-base ${
+                    errors.content
+                      ? "border-[#FF6B6B] bg-[#FFF5F5]"
+                      : "border-[#E5E5EA] bg-[#F9F9FB] focus:border-[#5856D6]"
+                  }`}
+                  placeholder="10글자 이상 입력해 주세요."
+                />
+                {errors.content && (
+                  <p className="text-[12px] text-[#FF6B6B]">{errors.content}</p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-full bg-[#5856D6] px-6 py-4 text-[15px] font-semibold text-white shadow-[0_12px_30px_rgba(88,86,214,0.35)] transition hover:bg-[#4B49C6] disabled:cursor-not-allowed disabled:bg-[#C7C7CC]"
+          >
+            작성하기
+          </button>
+        </form>
+      </main>
+
+      <FooterNav />
+    </div>
+  );
+};
+
+export default QnaCreate;

--- a/src/pages/QnaDetail.tsx
+++ b/src/pages/QnaDetail.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { server } from "@/utils/axios";
+import FooterNav from "../components/FooterNav";
+
+type QnaDetail = {
+  id: string;
+  title: string;
+  content: string;
+};
+
+const QnaDetailPage: React.FC = () => {
+  const { postId } = useParams();
+  const navigate = useNavigate();
+  const [qnaDetail, setQnaDetail] = useState<QnaDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [answer, setAnswer] = useState("");
+
+  useEffect(() => {
+    if (!postId) {
+      navigate("/not-found");
+      return;
+    }
+
+    setIsLoading(true);
+
+    server
+      .get(`/post/${postId}`)
+      .then((response) => {
+        const payload = response.data?.data ?? response.data;
+        setQnaDetail({
+          id: String(payload?.id ?? postId),
+          title: payload?.title ?? "",
+          content: payload?.content ?? "",
+        });
+      })
+      .catch(() => {
+        navigate("/not-found");
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [navigate, postId]);
+
+  return (
+    <div className="min-h-screen w-full bg-[#F2F2F7]" style={{ paddingBottom: "120px" }}>
+      <main className="mx-auto flex w-full max-w-screen-sm flex-col gap-6 px-4 pb-8 pt-8 sm:max-w-screen-md sm:px-6 lg:max-w-4xl">
+        {isLoading && (
+          <div className="rounded-[18px] bg-white p-6 text-center text-[#8E8E93]">
+            Q&A 정보를 불러오는 중입니다...
+          </div>
+        )}
+
+        {!isLoading && qnaDetail && (
+          <section className="rounded-[18px] bg-white p-6 shadow-sm">
+            <span className="text-[12px] font-semibold text-[#5856D6]">Q&A</span>
+            <h1 className="mt-2 text-[20px] font-bold text-[#1C1C1E]">{qnaDetail.title}</h1>
+            <p className="mt-4 whitespace-pre-line text-[14px] text-[#3A3A3C]">
+              {qnaDetail.content}
+            </p>
+          </section>
+        )}
+      </main>
+
+      <div className="fixed bottom-20 left-0 right-0 z-20 border-t border-[#E5E5EA] bg-white px-6 py-4 shadow-[0_-8px_24px_rgba(26,26,26,0.08)]">
+        <div className="mx-auto flex w-full max-w-screen-sm flex-col gap-3 sm:max-w-screen-md lg:max-w-4xl">
+          <label className="text-[12px] font-semibold text-[#8E8E93]">답변 작성</label>
+          <textarea
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            rows={3}
+            className="w-full resize-none rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-sm font-medium text-[#1C1C1E] focus:border-[#5856D6] focus:outline-none"
+            placeholder="답변을 입력해 주세요."
+          />
+          <button
+            type="button"
+            className="w-full rounded-full bg-[#5856D6] px-6 py-3 text-[14px] font-semibold text-white transition hover:bg-[#4B49C6]"
+          >
+            답변 등록
+          </button>
+        </div>
+      </div>
+
+      <FooterNav />
+    </div>
+  );
+};
+
+export default QnaDetailPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -92,3 +92,5 @@ export { default as AdminPermission } from "./admin/Permission";
 export { default as MeetVote } from "./admin/MeetVote";
 export { default as NotificationCreate } from "./admin/Notification";
 export { default as VoteCreate } from "./admin/VoteCreate";
+export { default as QnaCreate } from "./QnaCreate";
+export { default as QnaDetail } from "./QnaDetail";

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -8,6 +8,9 @@ export type Post = {
   isAuthor: string | null;     
   participantsNum: string | null; 
   participants: string[] | null; 
+  answerStatus?: string | null;
+  answered?: boolean | null;
+  answerYn?: string | null;
 };
 
 export type Place = {

--- a/src/utils/router.tsx
+++ b/src/utils/router.tsx
@@ -48,6 +48,10 @@ const router: RouteObject[] = [
     element: <Pages.PostList />,
   },
   {
+    path: "/post/create/question",
+    element: <Pages.QnaCreate />,
+  },
+  {
     path: "/not-found",
     element: <Pages.NotFound />,
   },
@@ -62,6 +66,10 @@ const router: RouteObject[] = [
   {
     path: "/post/:postId",
     element: <Pages.PostDetail />,
+  },
+  {
+    path: "/post/question/:postId",
+    element: <Pages.QnaDetail />,
   },
   {
     path: "/meet/join/:meetId",


### PR DESCRIPTION
### Motivation
- Provide a Q&A workflow so users can create and view question posts and see answered/unanswered state in the post list. 
- Surface answer state consistently across different backend shapes and fix display issues reported in the Q&A list rows. 

### Description
- Add `QnaCreate` and `QnaDetail` pages (`src/pages/QnaCreate.tsx`, `src/pages/QnaDetail.tsx`) providing a Q&A creation form with validation and a detail view with reply UI. 
- Extend `Post` type with optional fields `answerStatus`, `answered`, and `answerYn` in `src/types/Post.ts` to support multiple backend shapes for answer state. 
- Update `PostList` (`src/pages/PostList.tsx`) to include `Q&A` tab in `TYPE_ORDER`, compute and reuse `answerStatus` per row, show an answer-status badge for Q&A rows, provide a fallback `Q&A` label when `post.type` is missing, and route Q&A items to `/post/question/:postId`. 
- Register the new pages in `src/pages/index.tsx` and add routes for `POST /post/create/question` and `GET /post/question/:postId` in `src/utils/router.tsx`. 

### Testing
- Ran `npm run build` (which runs `tsc && vite build`) and the production build completed successfully (succeeded). 
- Started the dev server with `npm run dev` and Vite reported ready and served the app (succeeded). 
- Attempted a Playwright smoke script to open `/post/list` and click the `Q&A` tab, but the browser script timed out in this environment (failed due to environment timeout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb26caf988324a2fc146d3343dfce)