### PR TITLE
Adjust time input wheel behavior for precise control

### DIFF
--- a/src/components/ScheduleVoteBefore.tsx
+++ b/src/components/ScheduleVoteBefore.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { server } from "@/utils/axios";
 import { Schedule } from "@/types/ScheduleVote";
+import { createTimeWheelHandler } from "@/utils/timeInput";
 
 type ScheduleVoteBeforeProps = {
   meetId: string;
@@ -149,6 +150,8 @@ const ScheduleVoteBefore = ({
             type="time"
             value={newTime}
             onChange={handleTimeChange}
+            onWheel={createTimeWheelHandler(setNewTime)}
+            step="60"
             className="border border-[#F2F2F7] rounded-lg px-2 py-1 w-full"
             />
             <div className="flex space-x-2">

--- a/src/pages/MeetCreate.tsx
+++ b/src/pages/MeetCreate.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import FooterNav from "../components/FooterNav";
 import { server } from "@/utils/axios";
 import SearchPopup from "../components/popUp/PlaceSearch"; // 팝업 컴포넌트
+import { createTimeWheelHandler } from "@/utils/timeInput";
 
 const MeetCreate: React.FC = () => {
     const [title, setTitle] = useState("");
@@ -126,6 +127,8 @@ const MeetCreate: React.FC = () => {
                                 type="time"
                                 value={time}
                                 onChange={(e) => setTime(e.target.value)}
+                                onWheel={createTimeWheelHandler(setTime)}
+                                step="60"
                                 className={`mt-2 block w-full text-[18px] font-bold 
                                 ${isDateTimeDisabled ? "bg-gray-300 text-gray-400" : time ? "text-black" : "text-gray-400 bg-transparent"}`}
                                 disabled={isDateTimeDisabled}

--- a/src/pages/MeetEdit.tsx
+++ b/src/pages/MeetEdit.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { server } from "@/utils/axios";
 import FooterNav from "../components/FooterNav";
 import SearchPopup from "../components/popUp/PlaceSearch"; // 팝업 컴포넌트
+import { createTimeWheelHandler } from "@/utils/timeInput";
 
 const MeetEdit: React.FC = () => {
   const navigate = useNavigate();
@@ -144,6 +145,8 @@ const MeetEdit: React.FC = () => {
               type="time"
               value={time}
               onChange={(e) => setTime(e.target.value)}
+              onWheel={createTimeWheelHandler(setTime)}
+              step="60"
               className="mt-2 block w-full text-[18px] font-bold bg-transparent"
             />
           </div>

--- a/src/pages/admin/MeetVote.tsx
+++ b/src/pages/admin/MeetVote.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { server } from "@/utils/axios";
 import FooterNav from "../../components/FooterNav";
 import SearchPopup from "../../components/popUp/PlaceSearch";
+import { createTimeWheelHandler } from "@/utils/timeInput";
 
 type VotePlace = { name: string; xPos: string; yPos: string };
 
@@ -161,6 +162,8 @@ const MeetVote = () => {
             type="time"
             value={voteTime}
             onChange={(e) => setVoteTime(e.target.value)}
+            onWheel={createTimeWheelHandler(setVoteTime)}
+            step="60"
             className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
           />
         </div>

--- a/src/utils/timeInput.ts
+++ b/src/utils/timeInput.ts
@@ -1,0 +1,85 @@
+import type { WheelEvent } from "react";
+
+const MINUTES_IN_DAY = 24 * 60;
+
+const normalizeWheelDelta = (event: WheelEvent<HTMLInputElement>) => {
+  if (event.deltaMode === 1) {
+    return event.deltaY * 16;
+  }
+
+  if (event.deltaMode === 2) {
+    return event.deltaY * 120;
+  }
+
+  return event.deltaY;
+};
+
+const getStepMinutes = (delta: number) => {
+  const absDelta = Math.abs(delta);
+
+  if (absDelta >= 120) {
+    return 15;
+  }
+
+  if (absDelta >= 60) {
+    return 10;
+  }
+
+  if (absDelta >= 20) {
+    return 5;
+  }
+
+  return 1;
+};
+
+const parseTimeValue = (value: string) => {
+  const [hoursValue, minutesValue] = value.split(":");
+  const hours = Number(hoursValue);
+  const minutes = Number(minutesValue);
+
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+
+  return hours * 60 + minutes;
+};
+
+const formatTimeValue = (totalMinutes: number) => {
+  const clamped = Math.min(Math.max(totalMinutes, 0), MINUTES_IN_DAY - 1);
+  const hours = Math.floor(clamped / 60);
+  const minutes = clamped % 60;
+
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+};
+
+export const createTimeWheelHandler =
+  (onChange: (value: string) => void) =>
+  (event: WheelEvent<HTMLInputElement>) => {
+    if (document.activeElement !== event.currentTarget) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const normalizedDelta = normalizeWheelDelta(event);
+
+    if (normalizedDelta === 0) {
+      return;
+    }
+
+    const currentValue = event.currentTarget.value || "00:00";
+    const currentMinutes = parseTimeValue(currentValue);
+    const baseMinutes = currentMinutes ?? 0;
+    const direction = normalizedDelta > 0 ? 1 : -1;
+    const stepMinutes = getStepMinutes(normalizedDelta);
+    const nextMinutes = baseMinutes + direction * stepMinutes;
+
+    onChange(formatTimeValue(nextMinutes));
+  };


### PR DESCRIPTION
### Motivation

- Users reported that scrolling the time inputs moved the value in large jumps (two steps) and was hard to select precise times. 
- The goal is to make fast/large scrolls advance by larger minute increments and small scrolls advance by smaller increments. 
- Improve ability to enter exact times via mouse wheel while keeping native keyboard/input behavior intact.

### Description

- Added a reusable utility `createTimeWheelHandler` in `src/utils/timeInput.ts` that normalizes wheel deltas, maps scroll magnitude to minute steps (1/5/10/15), parses and formats `HH:MM`, and clamps values within a day. 
- Wired the handler into time inputs by adding `onWheel={createTimeWheelHandler(...)}` to `src/pages/MeetCreate.tsx`, `src/pages/MeetEdit.tsx`, `src/pages/admin/MeetVote.tsx`, and `src/components/ScheduleVoteBefore.tsx`. 
- Set `step="60"` on the time inputs to align the native step granularity with minute-based adjustments. 
- The handler only responds when the input is focused and prevents the default wheel scroll to avoid page scrolling while adjusting time.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f715e746c832480d2ac138a37f3ba)