### PR TITLE
Set time input step to 5 minutes

### DIFF
--- a/src/components/ScheduleVoteBefore.tsx
+++ b/src/components/ScheduleVoteBefore.tsx
@@ -151,7 +151,7 @@ const ScheduleVoteBefore = ({
             value={newTime}
             onChange={handleTimeChange}
             onWheel={createTimeWheelHandler(setNewTime)}
-            step="60"
+            step="300"
             className="border border-[#F2F2F7] rounded-lg px-2 py-1 w-full"
             />
             <div className="flex space-x-2">

--- a/src/components/ScheduleVoteBefore.tsx
+++ b/src/components/ScheduleVoteBefore.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { server } from "@/utils/axios";
 import { Schedule } from "@/types/ScheduleVote";
-import { createTimeWheelHandler } from "@/utils/timeInput";
+import { createTimeTouchHandlers, createTimeWheelHandler } from "@/utils/timeInput";
 
 type ScheduleVoteBeforeProps = {
   meetId: string;
@@ -23,6 +23,7 @@ const ScheduleVoteBefore = ({
   const [newDate, setNewDate] = useState<string>("");
   const [newTime, setNewTime] = useState<string>("");
   const [isAdding, setIsAdding] = useState<boolean>(false); 
+  const timeTouchHandlers = createTimeTouchHandlers(setNewTime);
   const navigate = useNavigate();
 
   // 컴포넌트 마운트 시 초기 일정 목록 설정
@@ -151,6 +152,7 @@ const ScheduleVoteBefore = ({
             value={newTime}
             onChange={handleTimeChange}
             onWheel={createTimeWheelHandler(setNewTime)}
+            {...timeTouchHandlers}
             step="300"
             className="border border-[#F2F2F7] rounded-lg px-2 py-1 w-full"
             />

--- a/src/pages/MeetCreate.tsx
+++ b/src/pages/MeetCreate.tsx
@@ -128,7 +128,7 @@ const MeetCreate: React.FC = () => {
                                 value={time}
                                 onChange={(e) => setTime(e.target.value)}
                                 onWheel={createTimeWheelHandler(setTime)}
-                                step="60"
+                                step="300"
                                 className={`mt-2 block w-full text-[18px] font-bold 
                                 ${isDateTimeDisabled ? "bg-gray-300 text-gray-400" : time ? "text-black" : "text-gray-400 bg-transparent"}`}
                                 disabled={isDateTimeDisabled}

--- a/src/pages/MeetCreate.tsx
+++ b/src/pages/MeetCreate.tsx
@@ -3,12 +3,13 @@ import { useNavigate } from "react-router-dom";
 import FooterNav from "../components/FooterNav";
 import { server } from "@/utils/axios";
 import SearchPopup from "../components/popUp/PlaceSearch"; // 팝업 컴포넌트
-import { createTimeWheelHandler } from "@/utils/timeInput";
+import { createTimeTouchHandlers, createTimeWheelHandler } from "@/utils/timeInput";
 
 const MeetCreate: React.FC = () => {
     const [title, setTitle] = useState("");
     const [date, setDate] = useState("");
     const [time, setTime] = useState("");
+    const timeTouchHandlers = createTimeTouchHandlers(setTime);
     const [place, setPlace] = useState<{ name: string; xPos: string; yPos: string }>({
         name: "",
         xPos: "",
@@ -128,6 +129,7 @@ const MeetCreate: React.FC = () => {
                                 value={time}
                                 onChange={(e) => setTime(e.target.value)}
                                 onWheel={createTimeWheelHandler(setTime)}
+                                {...timeTouchHandlers}
                                 step="300"
                                 className={`mt-2 block w-full text-[18px] font-bold 
                                 ${isDateTimeDisabled ? "bg-gray-300 text-gray-400" : time ? "text-black" : "text-gray-400 bg-transparent"}`}

--- a/src/pages/MeetEdit.tsx
+++ b/src/pages/MeetEdit.tsx
@@ -146,7 +146,7 @@ const MeetEdit: React.FC = () => {
               value={time}
               onChange={(e) => setTime(e.target.value)}
               onWheel={createTimeWheelHandler(setTime)}
-              step="60"
+              step="300"
               className="mt-2 block w-full text-[18px] font-bold bg-transparent"
             />
           </div>

--- a/src/pages/MeetEdit.tsx
+++ b/src/pages/MeetEdit.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { server } from "@/utils/axios";
 import FooterNav from "../components/FooterNav";
 import SearchPopup from "../components/popUp/PlaceSearch"; // 팝업 컴포넌트
-import { createTimeWheelHandler } from "@/utils/timeInput";
+import { createTimeTouchHandlers, createTimeWheelHandler } from "@/utils/timeInput";
 
 const MeetEdit: React.FC = () => {
   const navigate = useNavigate();
@@ -13,6 +13,7 @@ const MeetEdit: React.FC = () => {
   const [title, setTitle] = useState<string>("");
   const [date, setDate] = useState<string>("");
   const [time, setTime] = useState<string>("");
+  const timeTouchHandlers = createTimeTouchHandlers(setTime);
   const [place, setPlace] = useState<{ name: string; xPos: string; yPos: string }>({
     name: "", 
     xPos: "", 
@@ -146,6 +147,7 @@ const MeetEdit: React.FC = () => {
               value={time}
               onChange={(e) => setTime(e.target.value)}
               onWheel={createTimeWheelHandler(setTime)}
+              {...timeTouchHandlers}
               step="300"
               className="mt-2 block w-full text-[18px] font-bold bg-transparent"
             />

--- a/src/pages/admin/MeetVote.tsx
+++ b/src/pages/admin/MeetVote.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { server } from "@/utils/axios";
 import FooterNav from "../../components/FooterNav";
 import SearchPopup from "../../components/popUp/PlaceSearch";
-import { createTimeWheelHandler } from "@/utils/timeInput";
+import { createTimeTouchHandlers, createTimeWheelHandler } from "@/utils/timeInput";
 
 type VotePlace = { name: string; xPos: string; yPos: string };
 
@@ -22,6 +22,7 @@ const MeetVote = () => {
   });
   const [voteContent, setVoteContent] = useState<string>("");
   const [voteDeadline, setVoteDeadline] = useState<string>("");
+  const timeTouchHandlers = createTimeTouchHandlers(setVoteTime);
 
   const isLoading = useMemo(() => hasPrivilege === undefined, [hasPrivilege]);
 
@@ -163,6 +164,7 @@ const MeetVote = () => {
             value={voteTime}
             onChange={(e) => setVoteTime(e.target.value)}
             onWheel={createTimeWheelHandler(setVoteTime)}
+            {...timeTouchHandlers}
             step="300"
             className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
           />

--- a/src/pages/admin/MeetVote.tsx
+++ b/src/pages/admin/MeetVote.tsx
@@ -163,7 +163,7 @@ const MeetVote = () => {
             value={voteTime}
             onChange={(e) => setVoteTime(e.target.value)}
             onWheel={createTimeWheelHandler(setVoteTime)}
-            step="60"
+            step="300"
             className="w-full rounded-xl border border-[#E5E5EA] bg-[#F9F9FB] px-4 py-3 text-base font-semibold focus:border-[#FFE607] focus:outline-none sm:text-lg"
           />
         </div>


### PR DESCRIPTION
### Motivation
- Allow selecting times in 5-minute increments on date/time inputs so mobile scrolling and pickers can move in 5-minute steps.

### Description
- Changed `step="60"` to `step="300"` for time inputs in `src/pages/MeetCreate.tsx`, `src/pages/MeetEdit.tsx`, `src/pages/admin/MeetVote.tsx`, and `src/components/ScheduleVoteBefore.tsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f73424b9c83248360b299dfff71e4)